### PR TITLE
Bugfix/1.3.1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,9 @@
 # Changelog
+## [1.3.1]
+### Bug fixes
+- `obj_to_dict`: Fixed `dict` inputs not being recognized as valid — dicts are now returned as-is instead of raising `ValueError`.
+- `obj_to_dict`: Added specific error message when `list` or `tuple` is passed (previously raised a generic error).
+
 ## [1.3.0]
 ### General
 - Updated dependency versions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,12 @@ dependencies = [
     "simple-log-factory==1.0.0",
     "requests>=2.32.5",
     "pydantic>=2.12.5",
-    "typing-extensions==4.15.0"
+    "typing-extensions==4.15.0",
+    # Adding this dependency explicitly to solve security issues while requests doesn't catch up. Refs:
+    # https://github.com/brenordv/pypi-raccoon-tools/security/dependabot/1
+    # https://github.com/brenordv/pypi-raccoon-tools/security/dependabot/2
+    # https://github.com/brenordv/pypi-raccoon-tools/security/dependabot/3
+    "urllib3>=2.6.3" # Adding
 ]
 requires-python = ">=3.9"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "raccoontools"
-version = "1.3.0"
+version = "1.3.1"
 description = "A collection of tools, and helpers that I usually want for a handful of projects, so to avoid rewriting them every time, I decided to create this package."
 readme = "readme.md"
 license = { text = "MIT License" }

--- a/raccoontools/shared/serializer.py
+++ b/raccoontools/shared/serializer.py
@@ -17,20 +17,22 @@ def obj_to_dict(obj) -> dict:
     :return: Dict representation of the object.
     :raises ValueError: If the object can't be converted to a dict.
     """
+    if isinstance(obj, dict):
+        return obj
 
     if issubclass(type(obj), BaseModel):
         # If it's a BaseModel, convert it to a dict using model_dump (Pydantic v2).
-        obj = obj.model_dump()
+        return obj.model_dump()
 
-    elif hasattr(obj, '__dict__'):
+    if hasattr(obj, '__dict__'):
         # If it's an object, convert it to a dict using the __dict__ attribute.
-        obj = obj.__dict__
-    else:
-        # Else: No idea how to convert it to a dict, so just return it as is.
-        raise ValueError(f"Could not convert object of type {type(obj)} to a dict.")
+        return obj.__dict__
 
-    # Return the (hopefully) converted object.
-    return obj
+    if isinstance(obj, (list, tuple)):
+        raise ValueError(f"Could not convert object of type {type(obj)} to a dict. Lists and tuples are not supported.")
+
+    # Else: No idea how to convert it to a dict.
+    raise ValueError(f"Could not convert object of type {type(obj)} to a dict.")
 
 
 def serialize_to_dict(obj, obj_serializer: callable = None) -> Union[dict, List[dict], None]:

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -46,6 +46,28 @@ class TestObjToDict:
         result = obj_to_dict(Simple())
         assert result == {"x": 1, "y": 2}
 
+    def test_dict_passthrough(self):
+        """Bug fix 1.3.1 regression: dicts should be returned as-is."""
+        d = {"key": "value", "num": 42}
+        result = obj_to_dict(d)
+        assert result is d
+
+    def test_empty_dict_passthrough(self):
+        """Bug fix 1.3.1 regression: empty dicts should be returned as-is."""
+        d = {}
+        result = obj_to_dict(d)
+        assert result is d
+
+    def test_raises_on_list(self):
+        """Bug fix 1.3.1 regression: lists should raise with specific message."""
+        with pytest.raises(ValueError, match="Lists and tuples are not supported"):
+            obj_to_dict([1, 2, 3])
+
+    def test_raises_on_tuple(self):
+        """Bug fix 1.3.1 regression: tuples should raise with specific message."""
+        with pytest.raises(ValueError, match="Lists and tuples are not supported"):
+            obj_to_dict((1, 2, 3))
+
     def test_raises_on_primitive(self):
         with pytest.raises(ValueError, match="Could not convert"):
             obj_to_dict(42)

--- a/uv.lock
+++ b/uv.lock
@@ -303,7 +303,7 @@ wheels = [
 
 [[package]]
 name = "raccoontools"
-version = "1.3.0"
+version = "1.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -311,6 +311,7 @@ dependencies = [
     { name = "requests" },
     { name = "simple-log-factory" },
     { name = "typing-extensions" },
+    { name = "urllib3" },
 ]
 
 [package.metadata]
@@ -320,6 +321,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.32.5" },
     { name = "simple-log-factory", specifier = "==1.0.0" },
     { name = "typing-extensions", specifier = "==4.15.0" },
+    { name = "urllib3", specifier = ">=2.6.3" },
 ]
 
 [[package]]
@@ -369,9 +371,9 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.5.0"
+version = "2.6.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
 ]


### PR DESCRIPTION
## [1.3.1]
### Bug fixes
- `obj_to_dict`: Fixed `dict` inputs not being recognized as valid — dicts are now returned as-is instead of raising `ValueError`.
- `obj_to_dict`: Added specific error message when `list` or `tuple` is passed (previously raised a generic error).