### PR TITLE
Bugfix: 1.3.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Check out the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -37,10 +37,10 @@ jobs:
 
     steps:
       - name: Check out the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.14'
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,8 @@
 ## [1.3.1]
 ### Bug fixes
 - `obj_to_dict`: Fixed `dict` inputs not being recognized as valid — dicts are now returned as-is instead of raising `ValueError`.
-- `obj_to_dict`: Added specific error message when `list` or `tuple` is passed (previously raised a generic error).
+- `obj_to_dict`: Added a specific error message when `list` or `tuple` is passed (previously raised a generic error).
+- `sentence_generator`: Fixed flaky sentence generation where `min_length=1` could produce a period-only string (`'.'`), causing the first character to not be uppercase.
 
 ## [1.3.0]
 ### General

--- a/raccoontools/generators/sequence_generators.py
+++ b/raccoontools/generators/sequence_generators.py
@@ -123,7 +123,7 @@ def sentence_generator(sentences_to_generate: Optional[int] = None,
 
     while sentences_to_generate is None or sentences_generated < sentences_to_generate:
         # Determine the length of this sentence
-        lower = max(min_length, 1)
+        lower = max(min_length, 2)
         if max_length is None:
             upper = max(lower, random.randint(10, 512))
         else:

--- a/raccoontools/generators/sequence_generators.py
+++ b/raccoontools/generators/sequence_generators.py
@@ -82,14 +82,14 @@ def timestamp_generator(timestamps_to_generate: Optional[int] = None) -> Generat
 
 
 def sentence_generator(sentences_to_generate: Optional[int] = None,
-                       min_length: int = 1,
+                       min_length: int = 2,
                        max_length: Optional[int] = None) -> Generator[str, None, None]:
     """
     Generate Lorem Ipsum sentences with lengths ranging from min_length to max_length.
 
     Args:
         sentences_to_generate (Optional[int]): The number of sentences to generate. If None, generates indefinitely.
-        min_length (int): The minimum length of each sentence. Default is 1.
+        min_length (int): The minimum length of each sentence. Default is 2.
         max_length (Optional[int]): The maximum length of each sentence.
                                     If None, a random value between 10 and 512 is used for each sentence.
 


### PR DESCRIPTION
# In this PR
Fixed flaky sentence generation in `sentence_generator` for `min_length=1` by adjusting lower-bound logic. Updated GitHub Actions to use latest versions (`checkout@v6`, `setup-python@v6`). 

## [1.3.1]
### Bug fixes
- `obj_to_dict`: Fixed `dict` inputs not being recognized as valid — dicts are now returned as-is instead of raising `ValueError`.
- `obj_to_dict`: Added a specific error message when `list` or `tuple` is passed (previously raised a generic error).
- `sentence_generator`: Fixed flaky sentence generation where `min_length=1` could produce a period-only string (`'.'`), causing the first character to not be uppercase.