### PR TITLE
New Version: 2.0.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
       - name: Check out the code

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 # Changelog
 ## [2.0.0]
 ### Breaking changes
-- Dropped Python 3.9 support. Minimum required version is now Python 3.10.
+- Dropped Python 3.9 support. The minimum required version is now Python 3.10.
 
 ### General
 - Modernized type hints across the codebase: replaced `Union`, `Optional`, `List`, `Dict`, `Tuple`, and `Type` from `typing` with PEP 604 (`X | Y`) and PEP 585 (`list`, `dict`, `tuple`, `type`) syntax.

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,9 @@
 - Removed `typing-extensions` as a direct dependency (replaced `typing_extensions.TypedDict` with `typing.TypedDict`, available since Python 3.8).
 - Updated `requests` and `urllib3` dependency versions to address security vulnerabilities.
 
+### Bug fixes
+- `read_csv`: Fixed off-by-one error in `absolute_line_number` metadata (was reporting one line too high).
+
 ### Added
 - `get_date_based_subfolder`: New utility to create/get date-based subdirectories with configurable format, UTC support, and delta offsets.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,19 @@
 # Changelog
+## [2.0.0]
+### Breaking changes
+- Dropped Python 3.9 support. Minimum required version is now Python 3.10.
+
+### General
+- Modernized type hints across the codebase: replaced `Union`, `Optional`, `List`, `Dict`, `Tuple`, and `Type` from `typing` with PEP 604 (`X | Y`) and PEP 585 (`list`, `dict`, `tuple`, `type`) syntax.
+- Replaced `datetime.UTC` compatibility shim (`try/except ImportError`) with direct `timezone.utc` usage.
+- Updated CI pipeline to test Python 3.10–3.15 (removed 3.9).
+- Updated PyPI classifiers to reflect supported Python versions (3.10–3.14).
+- Removed `typing-extensions` as a direct dependency (replaced `typing_extensions.TypedDict` with `typing.TypedDict`, available since Python 3.8).
+- Updated `requests` and `urllib3` dependency versions to address security vulnerabilities.
+
+### Added
+- `get_date_based_subfolder`: New utility to create/get date-based subdirectories with configurable format, UTC support, and delta offsets.
+
 ## [1.3.1]
 ### Bug fixes
 - `obj_to_dict`: Fixed `dict` inputs not being recognized as valid — dicts are now returned as-is instead of raising `ValueError`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "raccoontools"
-version = "1.3.1"
+version = "2.0.0"
 description = "A collection of tools, and helpers that I usually want for a handful of projects, so to avoid rewriting them every time, I decided to create this package."
 readme = "readme.md"
 license = { text = "MIT License" }
@@ -17,25 +17,26 @@ classifiers = [
     "Intended Audience :: Information Technology",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
 dependencies = [
     "raccoon-simple-stopwatch==0.0.3",
     "simple-log-factory==1.0.0",
-    "requests>=2.32.5",
+    "requests>=2.33.1",
     "pydantic>=2.12.5",
-    "typing-extensions==4.15.0",
     # Adding this dependency explicitly to solve security issues while requests doesn't catch up. Refs:
     # https://github.com/brenordv/pypi-raccoon-tools/security/dependabot/1
     # https://github.com/brenordv/pypi-raccoon-tools/security/dependabot/2
     # https://github.com/brenordv/pypi-raccoon-tools/security/dependabot/3
     "urllib3>=2.6.3" # Adding
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 [project.urls]
 "Homepage" = "https://github.com/brenordv/pypi-raccoon-tools"
@@ -45,5 +46,5 @@ requires-python = ">=3.9"
 "Author" = "https://raccoon.ninja"
 
 [build-system]
-requires = ["setuptools>=42", "wheel"]
+requires = ["setuptools>=75", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/raccoontools/decorators/benchmark.py
+++ b/raccoontools/decorators/benchmark.py
@@ -1,24 +1,21 @@
 import logging
+from collections.abc import Callable
+from datetime import datetime, timedelta, timezone
 from functools import wraps
-from typing import Callable, Any, Union
-from datetime import datetime, timedelta
-
-try:
-    from datetime import UTC
-except ImportError:
-    from datetime import timezone
-
-    UTC = timezone.utc
 from timeit import default_timer as timer
-from typing_extensions import TypedDict
+from typing import Any
+
+from typing import TypedDict
+
+UTC = timezone.utc
 
 
 class TimerInfo(TypedDict):
-    started_at: Union[datetime, None]
-    stopped_at: Union[datetime, None]
-    start_timer: Union[float, None]
-    end_timer: Union[float, None]
-    elapsed_time: Union[timedelta, None]
+    started_at: datetime | None
+    stopped_at: datetime | None
+    start_timer: float | None
+    end_timer: float | None
+    elapsed_time: timedelta | None
 
 
 def benchmark(func: Callable) -> Callable:
@@ -33,11 +30,11 @@ def benchmark(func: Callable) -> Callable:
     :param func: The function to benchmark
     :return: The decorated function
     """
-    started_at: Union[datetime, None] = None
-    stopped_at: Union[datetime, None] = None
-    start_timer: Union[float, None] = None
-    end_timer: Union[float, None] = None
-    elapsed_time: Union[timedelta, None] = None
+    started_at: datetime | None = None
+    stopped_at: datetime | None = None
+    start_timer: float | None = None
+    end_timer: float | None = None
+    elapsed_time: timedelta | None = None
 
     @wraps(func)
     def wrapper(*args, **kwargs) -> Any:

--- a/raccoontools/decorators/retry.py
+++ b/raccoontools/decorators/retry.py
@@ -17,7 +17,7 @@ def retry(
         retries: int = 3,
         delay: float = 1,
         delay_is_exponential: bool = False,
-        only_exceptions_of_type: list[type[BaseException]] = None,
+        only_exceptions_of_type: list[type[BaseException]] | None = None,
         log_level: int = logging.ERROR
 ) -> Callable | Any:
     """
@@ -82,7 +82,7 @@ def retry_request(
         delay: float = 1,
         delay_is_exponential: bool = False,
         skip_retry_on_404: bool = False,
-        retry_only_on_status_codes: list[int] = None,
+        retry_only_on_status_codes: list[int] | None = None,
         get_new_token_on_401: Callable[[], str] | None = None,
         get_new_token_on_403: Callable[[], str] | None = None,
         log_level: int = logging.ERROR

--- a/raccoontools/decorators/retry.py
+++ b/raccoontools/decorators/retry.py
@@ -1,7 +1,9 @@
 import logging
+from collections.abc import Callable
 from functools import wraps
 from time import sleep
-from typing import Callable, Any, List, Type, Optional, Union
+from typing import Any
+
 import requests
 
 from simple_log_factory.log_factory import log_factory
@@ -10,14 +12,14 @@ __logger_name = "RN.T:Retry"  # Racoon Ninja Tools: Retry Decorator
 
 
 def retry(
-        func: Optional[Callable] = None,
+        func: Callable | None = None,
         *,
         retries: int = 3,
         delay: float = 1,
         delay_is_exponential: bool = False,
-        only_exceptions_of_type: List[Type[BaseException]] = None,
+        only_exceptions_of_type: list[type[BaseException]] = None,
         log_level: int = logging.ERROR
-) -> Union[Callable, Any]:
+) -> Callable | Any:
     """
     A decorator that retries a function call a number of times before giving up.
 
@@ -74,17 +76,17 @@ def retry(
 
 
 def retry_request(
-        func: Optional[Callable] = None,
+        func: Callable | None = None,
         *,
         retries: int = 3,
         delay: float = 1,
         delay_is_exponential: bool = False,
         skip_retry_on_404: bool = False,
-        retry_only_on_status_codes: List[int] = None,
-        get_new_token_on_401: Optional[Callable[[], str]] = None,
-        get_new_token_on_403: Optional[Callable[[], str]] = None,
+        retry_only_on_status_codes: list[int] = None,
+        get_new_token_on_401: Callable[[], str] | None = None,
+        get_new_token_on_403: Callable[[], str] | None = None,
         log_level: int = logging.ERROR
-) -> Union[Callable, Any]:
+) -> Callable | Any:
     """
     A decorator that retries a http request a number of times before giving up.
 

--- a/raccoontools/generators/file_ops_generators.py
+++ b/raccoontools/generators/file_ops_generators.py
@@ -147,7 +147,7 @@ def read_csv(file: str | Path, encoding: str = "utf-8", has_headers: bool = True
         metadata = CsvRowMetadata(
             index=row_index,
             data_line_number=data_line_number,
-            absolute_line_number=row_index + 1,
+            absolute_line_number=row_index,
             raw_data=line_without_newline,
             headers=metadata_headers
         )

--- a/raccoontools/generators/file_ops_generators.py
+++ b/raccoontools/generators/file_ops_generators.py
@@ -1,6 +1,6 @@
 import csv
+from collections.abc import Generator
 from pathlib import Path
-from typing import Union, Generator, Optional, List, Tuple
 
 
 class CsvRowMetadata:
@@ -21,10 +21,10 @@ class CsvRowMetadata:
     raw_data: str
 
     """List of headers if present."""
-    headers: Optional[List[str]] = None
+    headers: list[str] | None = None
 
     def __init__(self, index: int = 0, data_line_number: int = 0, absolute_line_number: int = 0,
-                 raw_data: str = "", headers: Optional[List[str]] = None):
+                 raw_data: str = "", headers: list[str] | None = None):
         self.index = index
         self.data_line_number = data_line_number
         self.absolute_line_number = absolute_line_number
@@ -32,16 +32,16 @@ class CsvRowMetadata:
         self.headers = headers
 
 
-def read_line(file: Union[str, Path], strip_line: bool = True, encoding: str = "utf-8",
-              buffer_size: Optional[int] = None) -> Generator[str, None, None]:
+def read_line(file: str | Path, strip_line: bool = True, encoding: str = "utf-8",
+              buffer_size: int | None = None) -> Generator[str, None, None]:
     """
     Read a file line by line.
 
     Args:
-        file (Union[str, Path]): Path to the file.
+        file (str | Path): Path to the file.
         strip_line (bool): Strip whitespace from the beginning and end of each line. Defaults to True.
         encoding (str): File encoding. Defaults to 'utf-8'.
-        buffer_size (Optional[int]): Size of the read buffer in bytes. If None, the default system buffer is used.
+        buffer_size (int | None): Size of the read buffer in bytes. If None, the default system buffer is used.
 
     Yields:
         str: Each line from the file, stripped if strip_line is True.
@@ -76,16 +76,16 @@ def read_line(file: Union[str, Path], strip_line: bool = True, encoding: str = "
         raise IOError(f"Error reading file {file}: {str(e)}")
 
 
-def read_csv(file: Union[str, Path], encoding: str = "utf-8", has_headers: bool = True,
-              buffer_size: Optional[int] = None) -> Generator[Tuple[Union[dict, list], CsvRowMetadata], None, None]:
+def read_csv(file: str | Path, encoding: str = "utf-8", has_headers: bool = True,
+              buffer_size: int | None = None) -> Generator[tuple[dict | list, CsvRowMetadata], None, None]:
     """
     Read a csv file row by row.
 
     Args:
-        file (Union[str, Path]): Path to the file.
+        file (str | Path): Path to the file.
         encoding (str): File encoding. Defaults to 'utf-8'.
         has_headers (bool): If true, will assume the first line of the file is the header row. Defaults to True.
-        buffer_size (Optional[int]): Size of the read buffer in bytes. If None, the default system buffer is used.
+        buffer_size (int | None): Size of the read buffer in bytes. If None, the default system buffer is used.
 
     Yields:
         (dict, CsvRowMetadata): Each line yielded as a dictionary with headers as keys and data as values or a list
@@ -105,7 +105,7 @@ def read_csv(file: Union[str, Path], encoding: str = "utf-8", has_headers: bool 
         might not need that even with large files. If you're dealing with large files, play around with those values
         to see if it has any impact on performance.
     """
-    headers: Optional[List[str]] = None
+    headers: list[str] | None = None
     data_line_number = 0
 
     for row_index, raw_line in enumerate(
@@ -153,7 +153,3 @@ def read_csv(file: Union[str, Path], encoding: str = "utf-8", has_headers: bool 
         )
 
         yield row_data, metadata
-
-if __name__ == '__main__':
-    for row, mtd in read_csv("Z:\dev\projects\python\movie-recommendation\data\historical_data\letterboxd\watched.csv"):
-        print(row)

--- a/raccoontools/generators/misc_generators.py
+++ b/raccoontools/generators/misc_generators.py
@@ -1,7 +1,8 @@
-from typing import List, Any, Generator
+from collections.abc import Generator
+from typing import Any
 
 
-def infinite_iterator(list_to_iterate_over: List[Any]) -> Generator[Any, None, None]:
+def infinite_iterator(list_to_iterate_over: list[Any]) -> Generator[Any, None, None]:
     """
     Generate an infinite iterator from a list.
     """

--- a/raccoontools/generators/sequence_generators.py
+++ b/raccoontools/generators/sequence_generators.py
@@ -1,10 +1,10 @@
+import random
 import time
 import uuid
-from typing import Generator, Callable, Optional
-import random
+from collections.abc import Callable, Generator
 
 
-def id_guid_generator(ids_to_generate: Optional[int] = None) -> Generator[str, None, None]:
+def id_guid_generator(ids_to_generate: int | None = None) -> Generator[str, None, None]:
     """
     Generate unique GUID (Globally Unique Identifier) strings.
 
@@ -26,9 +26,9 @@ def id_guid_generator(ids_to_generate: Optional[int] = None) -> Generator[str, N
 
 
 def id_int_generator(
-    ids_to_generate: Optional[int] = None,
+    ids_to_generate: int | None = None,
     start_at: int = 0,
-    validate_id: Optional[Callable[[int], bool]] = None
+    validate_id: Callable[[int], bool] | None = None
 ) -> Generator[int, None, None]:
     """
     Generate integer IDs with optional validation.
@@ -59,7 +59,7 @@ def id_int_generator(
         ids_generated += 1
 
 
-def timestamp_generator(timestamps_to_generate: Optional[int] = None) -> Generator[int, None, None]:
+def timestamp_generator(timestamps_to_generate: int | None = None) -> Generator[int, None, None]:
     """
     Generate Unix timestamps.
 
@@ -81,9 +81,9 @@ def timestamp_generator(timestamps_to_generate: Optional[int] = None) -> Generat
         timestamps_generated += 1
 
 
-def sentence_generator(sentences_to_generate: Optional[int] = None,
+def sentence_generator(sentences_to_generate: int | None = None,
                        min_length: int = 2,
-                       max_length: Optional[int] = None) -> Generator[str, None, None]:
+                       max_length: int | None = None) -> Generator[str, None, None]:
     """
     Generate Lorem Ipsum sentences with lengths ranging from min_length to max_length.
 

--- a/raccoontools/shared/file_ops.py
+++ b/raccoontools/shared/file_ops.py
@@ -46,7 +46,7 @@ def load_json_from_file(
 def save_json_to_file(
         data: dict | list[dict],
         target_file_or_folder: Path,
-        dump_kwargs: dict = None,
+        dump_kwargs: dict | None = None,
         encoding: str = "utf-8"
 ) -> Path:
     """

--- a/raccoontools/shared/file_ops.py
+++ b/raccoontools/shared/file_ops.py
@@ -1,6 +1,6 @@
 import json
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable, Optional, Union, List
 
 from raccoontools.shared.file_utils import get_filename_for_new_file
 from raccoontools.shared.serializer import obj_dump_deserializer, obj_dump_serializer
@@ -17,8 +17,8 @@ _JSON_DUMPS_PARAMS = {
 def load_json_from_file(
         file: Path,
         encoding: str = "utf-8",
-        object_hook: Optional[Callable] = _USE_DEFAULT_HOOK,
-) -> Union[dict, List[dict]]:
+        object_hook: Callable | None = _USE_DEFAULT_HOOK,
+) -> dict | list[dict]:
     """
     Loads a JSON file and returns the data as dict or List[dict].
 
@@ -44,7 +44,7 @@ def load_json_from_file(
 
 
 def save_json_to_file(
-        data: Union[dict, List[dict]],
+        data: dict | list[dict],
         target_file_or_folder: Path,
         dump_kwargs: dict = None,
         encoding: str = "utf-8"

--- a/raccoontools/shared/file_utils.py
+++ b/raccoontools/shared/file_utils.py
@@ -65,7 +65,7 @@ def get_date_based_subfolder(
     Gets a subfolder for the reference date. Using the specified date format (by default YYYY-MM-DD).
 
     :param ref_path: Folder that will be used as the main folder. If a file is provided, will use the parent as the
-    base.
+    base. Caveat: If the path is a folder, doesn't exist, and have a dot in the name (i.e: '~/projects/my.project.data'), we'll assume it's a file.
     :param use_utc: If True, will use the UTC timezone. Only has an effect if date_ref is None.
     :param date_ref: The date to use as the reference. If None, will use the current date.
     :param add_delta_days: If informed, will add the delta days to the date.
@@ -73,7 +73,7 @@ def get_date_based_subfolder(
     :param create_if_missing: If True, will create the folder if it doesn't exist. (Default: True)
     :return: The subfolder path.
     """
-    base_path = ref_path.parent if ref_path.is_file() else ref_path
+    base_path = ref_path.parent if ref_path.is_file() or ref_path.suffix != "" else ref_path
 
     if date_ref is not None:
         target_date = date_ref

--- a/raccoontools/shared/file_utils.py
+++ b/raccoontools/shared/file_utils.py
@@ -65,7 +65,7 @@ def get_date_based_subfolder(
     Gets a subfolder for the reference date. Using the specified date format (by default YYYY-MM-DD).
 
     :param ref_path: Folder that will be used as the main folder. If a file is provided, will use the parent as the
-    base. Caveat: If the path is a folder, doesn't exist, and have a dot in the name (i.e: '~/projects/my.project.data'), we'll assume it's a file.
+    base. Caveat: If the path is a folder that doesn't exist, and has a dot in its name (i.e: '~/projects/my.project.data'), we'll assume it's a file.
     :param use_utc: If True, will use the UTC timezone. Only has an effect if date_ref is None.
     :param date_ref: The date to use as the reference. If None, will use the current date.
     :param add_delta_days: If informed, will add the delta days to the date.

--- a/raccoontools/shared/file_utils.py
+++ b/raccoontools/shared/file_utils.py
@@ -7,12 +7,12 @@ UTC = timezone.utc
 
 def get_filename_for_new_file(
         file_extension: str,
-        prefix: str = None,
+        prefix: str | None = None,
         add_current_datetime_as_format: str = "%Y%m%d%H%M%S%f",
         use_utc: bool = True,
         unique_identifier: str | bool = True,
         part_separator: str = "-",
-        suffix: str = None
+        suffix: str | None = None
 ) -> str:
     """
     Generates a filename for a new file.

--- a/raccoontools/shared/file_utils.py
+++ b/raccoontools/shared/file_utils.py
@@ -1,13 +1,8 @@
-from datetime import datetime
-
-try:
-    from datetime import UTC
-except ImportError:
-    from datetime import timezone
-
-    UTC = timezone.utc
-from typing import Union
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from uuid import uuid4
+
+UTC = timezone.utc
 
 
 def get_filename_for_new_file(
@@ -15,7 +10,7 @@ def get_filename_for_new_file(
         prefix: str = None,
         add_current_datetime_as_format: str = "%Y%m%d%H%M%S%f",
         use_utc: bool = True,
-        unique_identifier: Union[str, bool] = True,
+        unique_identifier: str | bool = True,
         part_separator: str = "-",
         suffix: str = None
 ) -> str:
@@ -56,3 +51,41 @@ def get_filename_for_new_file(
     filename = f"{part_separator.join(filename_parts)}{ext}"
 
     return filename
+
+
+def get_date_based_subfolder(
+        ref_path: Path,
+        use_utc: bool = True,
+        date_ref: datetime | None = None,
+        add_delta_days: int | None = None,
+        date_format: str = "%Y-%m-%d",
+        create_if_missing: bool = True
+) -> Path:
+    """
+    Gets a subfolder for the reference date. Using the specified date format (by default YYYY-MM-DD).
+
+    :param ref_path: Folder that will be used as the main folder. If a file is provided, will use the parent as the
+    base.
+    :param use_utc: If True, will use the UTC timezone. Only has an effect if date_ref is None.
+    :param date_ref: The date to use as the reference. If None, will use the current date.
+    :param add_delta_days: If informed, will add the delta days to the date.
+    :param date_format: The format of the date. (Default: "%Y-%m-%d")
+    :param create_if_missing: If True, will create the folder if it doesn't exist. (Default: True)
+    :return: The subfolder path.
+    """
+    base_path = ref_path.parent if ref_path.is_file() else ref_path
+
+    if date_ref is not None:
+        target_date = date_ref
+    else:
+        target_date = datetime.now(tz=UTC) if use_utc else datetime.now()
+
+    if add_delta_days is not None:
+        target_date += timedelta(days=add_delta_days)
+
+    new_folder = base_path.joinpath(target_date.strftime(date_format))
+
+    if create_if_missing and not new_folder.exists():
+        new_folder.mkdir(parents=True, exist_ok=True)
+
+    return new_folder

--- a/raccoontools/shared/http.py
+++ b/raccoontools/shared/http.py
@@ -24,9 +24,9 @@ def _get_header_value(key: str, value: str) -> dict[str, str]:
 def get_headers(
         token: str | None = None,
         content_type: str = "application/json",
-        user_agent: str = None,
+        user_agent: str | None = None,
         fake_browser_user_agent: bool = False,
-        extra_args: dict[str, str] = None) -> dict[str, str]:
+        extra_args: dict[str, str] | None = None) -> dict[str, str]:
     """
     Get the headers for an HTTP request.
     :param token: Authentication token. If None or empty, no Authorization header is set.

--- a/raccoontools/shared/http.py
+++ b/raccoontools/shared/http.py
@@ -3,7 +3,7 @@
 DEFAULT_FAKE_BROWSER_USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:128.0) Gecko/20100101 Firefox/128.0"
 
 
-def _get_header_user_agent(user_agent: str = None, fake_browser_user_agent: bool = False) -> dict[str, str]:
+def _get_header_user_agent(user_agent: str | None = None, fake_browser_user_agent: bool = False) -> dict[str, str]:
     if not user_agent and not fake_browser_user_agent:
         return {}
 

--- a/raccoontools/shared/http.py
+++ b/raccoontools/shared/http.py
@@ -1,10 +1,9 @@
-from typing import Dict, Optional
 
 # Now, why would you want to do something like this?
 DEFAULT_FAKE_BROWSER_USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:128.0) Gecko/20100101 Firefox/128.0"
 
 
-def _get_header_user_agent(user_agent: str = None, fake_browser_user_agent: bool = False) -> Dict[str, str]:
+def _get_header_user_agent(user_agent: str = None, fake_browser_user_agent: bool = False) -> dict[str, str]:
     if not user_agent and not fake_browser_user_agent:
         return {}
 
@@ -13,7 +12,7 @@ def _get_header_user_agent(user_agent: str = None, fake_browser_user_agent: bool
     }
 
 
-def _get_header_value(key: str, value: str) -> Dict[str, str]:
+def _get_header_value(key: str, value: str) -> dict[str, str]:
     if not value:
         return {}
 
@@ -23,11 +22,11 @@ def _get_header_value(key: str, value: str) -> Dict[str, str]:
 
 
 def get_headers(
-        token: Optional[str] = None,
+        token: str | None = None,
         content_type: str = "application/json",
         user_agent: str = None,
         fake_browser_user_agent: bool = False,
-        extra_args: Dict[str, str] = None) -> Dict[str, str]:
+        extra_args: dict[str, str] = None) -> dict[str, str]:
     """
     Get the headers for an HTTP request.
     :param token: Authentication token. If None or empty, no Authorization header is set.

--- a/raccoontools/shared/serializer.py
+++ b/raccoontools/shared/serializer.py
@@ -1,9 +1,11 @@
+import csv
 import warnings
+from collections.abc import Callable
 from datetime import datetime
 from io import StringIO
 from pathlib import Path
+
 from pydantic import BaseModel
-import csv
 
 
 _PATH_LIB_OBJ_TAG = "[PATHLIBOBJ]"
@@ -34,7 +36,7 @@ def obj_to_dict(obj) -> dict:
     raise ValueError(f"Could not convert object of type {type(obj)} to a dict.")
 
 
-def serialize_to_dict(obj, obj_serializer: callable = None) -> dict | list[dict] | None:
+def serialize_to_dict(obj, obj_serializer: Callable | None = None) -> dict | list[dict] | None:
     """
     Serialize obj to a dict or a list of dicts. Useful when sending complex objects in http requests.
     If the obj passed is a dict, will iterate over all the properties and convert them to dicts.

--- a/raccoontools/shared/serializer.py
+++ b/raccoontools/shared/serializer.py
@@ -2,7 +2,6 @@ import warnings
 from datetime import datetime
 from io import StringIO
 from pathlib import Path
-from typing import Union, List
 from pydantic import BaseModel
 import csv
 
@@ -35,7 +34,7 @@ def obj_to_dict(obj) -> dict:
     raise ValueError(f"Could not convert object of type {type(obj)} to a dict.")
 
 
-def serialize_to_dict(obj, obj_serializer: callable = None) -> Union[dict, List[dict], None]:
+def serialize_to_dict(obj, obj_serializer: callable = None) -> dict | list[dict] | None:
     """
     Serialize obj to a dict or a list of dicts. Useful when sending complex objects in http requests.
     If the obj passed is a dict, will iterate over all the properties and convert them to dicts.
@@ -71,7 +70,7 @@ def serialize_to_dict(obj, obj_serializer: callable = None) -> Union[dict, List[
     return serialized
 
 
-def parse_csv(csv_data: str) -> List[dict]:
+def parse_csv(csv_data: str) -> list[dict]:
     """
     Parses a CSV string and returns a list of dictionaries.
 
@@ -84,9 +83,9 @@ def parse_csv(csv_data: str) -> List[dict]:
 
 
 def csv_string_to_dict_list(
-        data: Union[str, List[str], dict, List[dict]],
+        data: str | list[str] | dict | list[dict],
         no_data_return: str = "No data available"
-) -> Union[List[dict], str]:
+) -> list[dict] | str:
     """
     Converts a CSV string to a list of dictionaries.
     The first row is considered the header row.
@@ -109,7 +108,7 @@ def csv_string_to_dict_list(
     return no_data_return
 
 
-def dataset_to_prompt_text(dataset: List[dict]) -> str:
+def dataset_to_prompt_text(dataset: list[dict]) -> str:
     """
     Converts a dataset to a prompt text.
     TODO: Explain a bit better what does this function do, and how to use it.

--- a/tests/test_file_ops_generators.py
+++ b/tests/test_file_ops_generators.py
@@ -1,0 +1,53 @@
+from raccoontools.generators.file_ops_generators import read_csv
+
+
+class TestReadCsvAbsoluteLineNumber:
+    def test_absolute_line_number_matches_file_line_with_headers(self, tmp_path):
+        csv_file = tmp_path / "data.csv"
+        csv_file.write_text("name,age\nAlice,30\nBob,25\nCharlie,40\n")
+
+        rows = list(read_csv(csv_file))
+
+        assert len(rows) == 3
+        # Header is line 1, so data starts at line 2
+        assert rows[0][1].absolute_line_number == 2
+        assert rows[1][1].absolute_line_number == 3
+        assert rows[2][1].absolute_line_number == 4
+
+    def test_absolute_line_number_matches_file_line_without_headers(self, tmp_path):
+        csv_file = tmp_path / "data.csv"
+        csv_file.write_text("Alice,30\nBob,25\nCharlie,40\n")
+
+        rows = list(read_csv(csv_file, has_headers=False))
+
+        assert len(rows) == 3
+        assert rows[0][1].absolute_line_number == 1
+        assert rows[1][1].absolute_line_number == 2
+        assert rows[2][1].absolute_line_number == 3
+
+    def test_data_line_number_is_one_based_data_only_counter(self, tmp_path):
+        csv_file = tmp_path / "data.csv"
+        csv_file.write_text("name,age\nAlice,30\nBob,25\n")
+
+        rows = list(read_csv(csv_file))
+
+        assert rows[0][1].data_line_number == 1
+        assert rows[1][1].data_line_number == 2
+
+    def test_row_data_parsed_correctly_with_headers(self, tmp_path):
+        csv_file = tmp_path / "data.csv"
+        csv_file.write_text("name,age\nAlice,30\nBob,25\n")
+
+        rows = list(read_csv(csv_file))
+
+        assert rows[0][0] == {"name": "Alice", "age": "30"}
+        assert rows[1][0] == {"name": "Bob", "age": "25"}
+
+    def test_row_data_parsed_as_list_without_headers(self, tmp_path):
+        csv_file = tmp_path / "data.csv"
+        csv_file.write_text("Alice,30\nBob,25\n")
+
+        rows = list(read_csv(csv_file, has_headers=False))
+
+        assert rows[0][0] == ["Alice", "30"]
+        assert rows[1][0] == ["Bob", "25"]

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -1,9 +1,5 @@
-import re
-from datetime import datetime, timedelta, timezone
-from pathlib import Path
+from datetime import datetime, timezone
 from unittest.mock import patch
-
-import pytest
 
 from raccoontools.shared.file_utils import (
     get_date_based_subfolder,

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -1,10 +1,14 @@
 import re
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
-from raccoontools.shared.file_utils import get_filename_for_new_file
+from raccoontools.shared.file_utils import (
+    get_date_based_subfolder,
+    get_filename_for_new_file,
+)
 
 
 class TestGetFilenameForNewFile:
@@ -93,3 +97,111 @@ class TestGetFilenameForNewFile:
             mock_dt.now.assert_called_once()
             call_kwargs = mock_dt.now.call_args
             assert call_kwargs.kwargs.get("tz") is not None
+
+
+class TestGetDateBasedSubfolder:
+    def test_basic_subfolder_with_fixed_date(self, tmp_path):
+        date_ref = datetime(2025, 3, 15, tzinfo=timezone.utc)
+        result = get_date_based_subfolder(
+            tmp_path, date_ref=date_ref, create_if_missing=False
+        )
+        assert result == tmp_path / "2025-03-15"
+
+    def test_creates_folder_when_missing(self, tmp_path):
+        date_ref = datetime(2025, 1, 1, tzinfo=timezone.utc)
+        result = get_date_based_subfolder(
+            tmp_path, date_ref=date_ref, create_if_missing=True
+        )
+        assert result.exists()
+        assert result.is_dir()
+
+    def test_does_not_create_folder_when_flag_is_false(self, tmp_path):
+        date_ref = datetime(2025, 1, 1, tzinfo=timezone.utc)
+        result = get_date_based_subfolder(
+            tmp_path, date_ref=date_ref, create_if_missing=False
+        )
+        assert not result.exists()
+
+    def test_existing_folder_is_not_recreated(self, tmp_path):
+        date_ref = datetime(2025, 6, 1, tzinfo=timezone.utc)
+        expected = tmp_path / "2025-06-01"
+        expected.mkdir()
+        marker = expected / "marker.txt"
+        marker.write_text("keep")
+
+        result = get_date_based_subfolder(
+            tmp_path, date_ref=date_ref, create_if_missing=True
+        )
+        assert result == expected
+        assert marker.read_text() == "keep"
+
+    def test_add_delta_days_positive(self, tmp_path):
+        date_ref = datetime(2025, 1, 30, tzinfo=timezone.utc)
+        result = get_date_based_subfolder(
+            tmp_path, date_ref=date_ref, add_delta_days=3,
+            create_if_missing=False
+        )
+        assert result == tmp_path / "2025-02-02"
+
+    def test_add_delta_days_negative(self, tmp_path):
+        date_ref = datetime(2025, 3, 1, tzinfo=timezone.utc)
+        result = get_date_based_subfolder(
+            tmp_path, date_ref=date_ref, add_delta_days=-1,
+            create_if_missing=False
+        )
+        assert result == tmp_path / "2025-02-28"
+
+    def test_custom_date_format(self, tmp_path):
+        date_ref = datetime(2025, 12, 5, tzinfo=timezone.utc)
+        result = get_date_based_subfolder(
+            tmp_path, date_ref=date_ref, date_format="%Y/%m/%d",
+            create_if_missing=False
+        )
+        assert result == tmp_path / "2025" / "12" / "05"
+
+    def test_ref_path_is_file_uses_parent(self, tmp_path):
+        file_path = tmp_path / "some_file.txt"
+        file_path.write_text("data")
+        date_ref = datetime(2025, 7, 4, tzinfo=timezone.utc)
+
+        result = get_date_based_subfolder(
+            file_path, date_ref=date_ref, create_if_missing=False
+        )
+        assert result == tmp_path / "2025-07-04"
+
+    def test_use_utc_true_calls_now_with_tz(self, tmp_path):
+        with patch(
+            "raccoontools.shared.file_utils.datetime"
+        ) as mock_dt:
+            mock_dt.now.return_value = datetime(
+                2025, 1, 1, tzinfo=timezone.utc
+            )
+            mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+
+            get_date_based_subfolder(
+                tmp_path, use_utc=True, create_if_missing=False
+            )
+            mock_dt.now.assert_called_once()
+            assert mock_dt.now.call_args.kwargs.get("tz") is not None
+
+    def test_use_utc_false_calls_now_without_tz(self, tmp_path):
+        with patch(
+            "raccoontools.shared.file_utils.datetime"
+        ) as mock_dt:
+            mock_dt.now.return_value = datetime(2025, 1, 1)
+            mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+
+            get_date_based_subfolder(
+                tmp_path, use_utc=False, create_if_missing=False
+            )
+            mock_dt.now.assert_called_once()
+            assert mock_dt.now.call_args.kwargs.get("tz") is None
+
+    def test_creates_nested_parents(self, tmp_path):
+        base = tmp_path / "a" / "b" / "c"
+        date_ref = datetime(2025, 1, 1, tzinfo=timezone.utc)
+        result = get_date_based_subfolder(
+            base, date_ref=date_ref, create_if_missing=True
+        )
+        assert result.exists()
+        assert result == base / "2025-01-01"

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -165,6 +165,24 @@ class TestGetDateBasedSubfolder:
         )
         assert result == tmp_path / "2025-07-04"
 
+    def test_nonexistent_path_with_extension_uses_parent(self, tmp_path):
+        fake_file = tmp_path / "output" / "report.json"
+        date_ref = datetime(2025, 7, 4, tzinfo=timezone.utc)
+
+        result = get_date_based_subfolder(
+            fake_file, date_ref=date_ref, create_if_missing=False
+        )
+        assert result == tmp_path / "output" / "2025-07-04"
+
+    def test_nonexistent_path_without_extension_treated_as_dir(self, tmp_path):
+        fake_dir = tmp_path / "output" / "reports"
+        date_ref = datetime(2025, 7, 4, tzinfo=timezone.utc)
+
+        result = get_date_based_subfolder(
+            fake_dir, date_ref=date_ref, create_if_missing=False
+        )
+        assert result == fake_dir / "2025-07-04"
+
     def test_use_utc_true_calls_now_with_tz(self, tmp_path):
         with patch(
             "raccoontools.shared.file_utils.datetime"

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 [[package]]
 name = "annotated-types"
@@ -106,22 +106,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/6f/8f7af07237c34a1defe7defc565a9bc1807762f672c0fde711a4b22bf9c0/charset_normalizer-3.4.4-cp314-cp314-win32.whl", hash = "sha256:f9d332f8c2a2fcbffe1378594431458ddbef721c1769d78e2cbc06280d8155f9", size = 99940, upload-time = "2025-10-14T04:41:49.946Z" },
     { url = "https://files.pythonhosted.org/packages/4b/51/8ade005e5ca5b0d80fb4aff72a3775b325bdc3d27408c8113811a7cbe640/charset_normalizer-3.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:8a6562c3700cce886c5be75ade4a5db4214fda19fede41d9792d100288d8f94c", size = 107104, upload-time = "2025-10-14T04:41:51.051Z" },
     { url = "https://files.pythonhosted.org/packages/da/5f/6b8f83a55bb8278772c5ae54a577f3099025f9ade59d0136ac24a0df4bde/charset_normalizer-3.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:de00632ca48df9daf77a2c65a484531649261ec9f25489917f09e455cb09ddb2", size = 100743, upload-time = "2025-10-14T04:41:52.122Z" },
-    { url = "https://files.pythonhosted.org/packages/46/7c/0c4760bccf082737ca7ab84a4c2034fcc06b1f21cf3032ea98bd6feb1725/charset_normalizer-3.4.4-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:a9768c477b9d7bd54bc0c86dbaebdec6f03306675526c9927c0e8a04e8f94af9", size = 209609, upload-time = "2025-10-14T04:42:10.922Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/a4/69719daef2f3d7f1819de60c9a6be981b8eeead7542d5ec4440f3c80e111/charset_normalizer-3.4.4-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1bee1e43c28aa63cb16e5c14e582580546b08e535299b8b6158a7c9c768a1f3d", size = 149029, upload-time = "2025-10-14T04:42:12.38Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/21/8d4e1d6c1e6070d3672908b8e4533a71b5b53e71d16828cc24d0efec564c/charset_normalizer-3.4.4-cp39-cp39-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:fd44c878ea55ba351104cb93cc85e74916eb8fa440ca7903e57575e97394f608", size = 144580, upload-time = "2025-10-14T04:42:13.549Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/0a/a616d001b3f25647a9068e0b9199f697ce507ec898cacb06a0d5a1617c99/charset_normalizer-3.4.4-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0f04b14ffe5fdc8c4933862d8306109a2c51e0704acfa35d51598eb45a1e89fc", size = 162340, upload-time = "2025-10-14T04:42:14.892Z" },
-    { url = "https://files.pythonhosted.org/packages/85/93/060b52deb249a5450460e0585c88a904a83aec474ab8e7aba787f45e79f2/charset_normalizer-3.4.4-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:cd09d08005f958f370f539f186d10aec3377d55b9eeb0d796025d4886119d76e", size = 159619, upload-time = "2025-10-14T04:42:16.676Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/21/0274deb1cc0632cd587a9a0ec6b4674d9108e461cb4cd40d457adaeb0564/charset_normalizer-3.4.4-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4fe7859a4e3e8457458e2ff592f15ccb02f3da787fcd31e0183879c3ad4692a1", size = 153980, upload-time = "2025-10-14T04:42:17.917Z" },
-    { url = "https://files.pythonhosted.org/packages/28/2b/e3d7d982858dccc11b31906976323d790dded2017a0572f093ff982d692f/charset_normalizer-3.4.4-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fa09f53c465e532f4d3db095e0c55b615f010ad81803d383195b6b5ca6cbf5f3", size = 152174, upload-time = "2025-10-14T04:42:19.018Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/ff/4a269f8e35f1e58b2df52c131a1fa019acb7ef3f8697b7d464b07e9b492d/charset_normalizer-3.4.4-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:7fa17817dc5625de8a027cb8b26d9fefa3ea28c8253929b8d6649e705d2835b6", size = 151666, upload-time = "2025-10-14T04:42:20.171Z" },
-    { url = "https://files.pythonhosted.org/packages/da/c9/ec39870f0b330d58486001dd8e532c6b9a905f5765f58a6f8204926b4a93/charset_normalizer-3.4.4-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:5947809c8a2417be3267efc979c47d76a079758166f7d43ef5ae8e9f92751f88", size = 145550, upload-time = "2025-10-14T04:42:21.324Z" },
-    { url = "https://files.pythonhosted.org/packages/75/8f/d186ab99e40e0ed9f82f033d6e49001701c81244d01905dd4a6924191a30/charset_normalizer-3.4.4-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:4902828217069c3c5c71094537a8e623f5d097858ac6ca8252f7b4d10b7560f1", size = 163721, upload-time = "2025-10-14T04:42:22.46Z" },
-    { url = "https://files.pythonhosted.org/packages/96/b1/6047663b9744df26a7e479ac1e77af7134b1fcf9026243bb48ee2d18810f/charset_normalizer-3.4.4-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:7c308f7e26e4363d79df40ca5b2be1c6ba9f02bdbccfed5abddb7859a6ce72cf", size = 152127, upload-time = "2025-10-14T04:42:23.712Z" },
-    { url = "https://files.pythonhosted.org/packages/59/78/e5a6eac9179f24f704d1be67d08704c3c6ab9f00963963524be27c18ed87/charset_normalizer-3.4.4-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:2c9d3c380143a1fedbff95a312aa798578371eb29da42106a29019368a475318", size = 161175, upload-time = "2025-10-14T04:42:24.87Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/43/0e626e42d54dd2f8dd6fc5e1c5ff00f05fbca17cb699bedead2cae69c62f/charset_normalizer-3.4.4-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:cb01158d8b88ee68f15949894ccc6712278243d95f344770fa7593fa2d94410c", size = 155375, upload-time = "2025-10-14T04:42:27.246Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/91/d9615bf2e06f35e4997616ff31248c3657ed649c5ab9d35ea12fce54e380/charset_normalizer-3.4.4-cp39-cp39-win32.whl", hash = "sha256:2677acec1a2f8ef614c6888b5b4ae4060cc184174a938ed4e8ef690e15d3e505", size = 99692, upload-time = "2025-10-14T04:42:28.425Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/a9/6c040053909d9d1ef4fcab45fddec083aedc9052c10078339b47c8573ea8/charset_normalizer-3.4.4-cp39-cp39-win_amd64.whl", hash = "sha256:f8e160feb2aed042cd657a72acc0b481212ed28b1b9a95c0cee1621b524e1966", size = 107192, upload-time = "2025-10-14T04:42:29.482Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/c6/4fa536b2c0cd3edfb7ccf8469fa0f363ea67b7213a842b90909ca33dd851/charset_normalizer-3.4.4-cp39-cp39-win_arm64.whl", hash = "sha256:b5d84d37db046c5ca74ee7bb47dd6cbc13f80665fdde3e8040bdd3fb015ecb50", size = 100220, upload-time = "2025-10-14T04:42:30.632Z" },
     { url = "https://files.pythonhosted.org/packages/0a/4c/925909008ed5a988ccbb72dcc897407e5d6d3bd72410d69e051fc0c14647/charset_normalizer-3.4.4-py3-none-any.whl", hash = "sha256:7a32c560861a02ff789ad905a2fe94e3f840803362c84fecf1851cb4cf3dc37f", size = 53402, upload-time = "2025-10-14T04:42:31.76Z" },
 ]
 
@@ -241,19 +225,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5c/96/5fb7d8c3c17bc8c62fdb031c47d77a1af698f1d7a406b0f79aaa1338f9ad/pydantic_core-2.41.5-cp314-cp314t-win32.whl", hash = "sha256:b4ececa40ac28afa90871c2cc2b9ffd2ff0bf749380fbdf57d165fd23da353aa", size = 1988906, upload-time = "2025-11-04T13:41:56.606Z" },
     { url = "https://files.pythonhosted.org/packages/22/ed/182129d83032702912c2e2d8bbe33c036f342cc735737064668585dac28f/pydantic_core-2.41.5-cp314-cp314t-win_amd64.whl", hash = "sha256:80aa89cad80b32a912a65332f64a4450ed00966111b6615ca6816153d3585a8c", size = 1981607, upload-time = "2025-11-04T13:41:58.889Z" },
     { url = "https://files.pythonhosted.org/packages/9f/ed/068e41660b832bb0b1aa5b58011dea2a3fe0ba7861ff38c4d4904c1c1a99/pydantic_core-2.41.5-cp314-cp314t-win_arm64.whl", hash = "sha256:35b44f37a3199f771c3eaa53051bc8a70cd7b54f333531c59e29fd4db5d15008", size = 1974769, upload-time = "2025-11-04T13:42:01.186Z" },
-    { url = "https://files.pythonhosted.org/packages/54/db/160dffb57ed9a3705c4cbcbff0ac03bdae45f1ca7d58ab74645550df3fbd/pydantic_core-2.41.5-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:8bfeaf8735be79f225f3fefab7f941c712aaca36f1128c9d7e2352ee1aa87bdf", size = 2107999, upload-time = "2025-11-04T13:42:03.885Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/7d/88e7de946f60d9263cc84819f32513520b85c0f8322f9b8f6e4afc938383/pydantic_core-2.41.5-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:346285d28e4c8017da95144c7f3acd42740d637ff41946af5ce6e5e420502dd5", size = 1929745, upload-time = "2025-11-04T13:42:06.075Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/c2/aef51e5b283780e85e99ff19db0f05842d2d4a8a8cd15e63b0280029b08f/pydantic_core-2.41.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a75dafbf87d6276ddc5b2bf6fae5254e3d0876b626eb24969a574fff9149ee5d", size = 1920220, upload-time = "2025-11-04T13:42:08.457Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/97/492ab10f9ac8695cd76b2fdb24e9e61f394051df71594e9bcc891c9f586e/pydantic_core-2.41.5-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7b93a4d08587e2b7e7882de461e82b6ed76d9026ce91ca7915e740ecc7855f60", size = 2067296, upload-time = "2025-11-04T13:42:10.817Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/23/984149650e5269c59a2a4c41d234a9570adc68ab29981825cfaf4cfad8f4/pydantic_core-2.41.5-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e8465ab91a4bd96d36dde3263f06caa6a8a6019e4113f24dc753d79a8b3a3f82", size = 2231548, upload-time = "2025-11-04T13:42:13.843Z" },
-    { url = "https://files.pythonhosted.org/packages/71/0c/85bcbb885b9732c28bec67a222dbed5ed2d77baee1f8bba2002e8cd00c5c/pydantic_core-2.41.5-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:299e0a22e7ae2b85c1a57f104538b2656e8ab1873511fd718a1c1c6f149b77b5", size = 2362571, upload-time = "2025-11-04T13:42:16.208Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/4a/412d2048be12c334003e9b823a3fa3d038e46cc2d64dd8aab50b31b65499/pydantic_core-2.41.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:707625ef0983fcfb461acfaf14de2067c5942c6bb0f3b4c99158bed6fedd3cf3", size = 2068175, upload-time = "2025-11-04T13:42:18.911Z" },
-    { url = "https://files.pythonhosted.org/packages/73/f4/c58b6a776b502d0a5540ad02e232514285513572060f0d78f7832ca3c98b/pydantic_core-2.41.5-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f41eb9797986d6ebac5e8edff36d5cef9de40def462311b3eb3eeded1431e425", size = 2177203, upload-time = "2025-11-04T13:42:22.578Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/ae/f06ea4c7e7a9eead3d165e7623cd2ea0cb788e277e4f935af63fc98fa4e6/pydantic_core-2.41.5-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:0384e2e1021894b1ff5a786dbf94771e2986ebe2869533874d7e43bc79c6f504", size = 2148191, upload-time = "2025-11-04T13:42:24.89Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/57/25a11dcdc656bf5f8b05902c3c2934ac3ea296257cc4a3f79a6319e61856/pydantic_core-2.41.5-cp39-cp39-musllinux_1_1_armv7l.whl", hash = "sha256:f0cd744688278965817fd0839c4a4116add48d23890d468bc436f78beb28abf5", size = 2343907, upload-time = "2025-11-04T13:42:27.683Z" },
-    { url = "https://files.pythonhosted.org/packages/96/82/e33d5f4933d7a03327c0c43c65d575e5919d4974ffc026bc917a5f7b9f61/pydantic_core-2.41.5-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:753e230374206729bf0a807954bcc6c150d3743928a73faffee51ac6557a03c3", size = 2322174, upload-time = "2025-11-04T13:42:30.776Z" },
-    { url = "https://files.pythonhosted.org/packages/81/45/4091be67ce9f469e81656f880f3506f6a5624121ec5eb3eab37d7581897d/pydantic_core-2.41.5-cp39-cp39-win32.whl", hash = "sha256:873e0d5b4fb9b89ef7c2d2a963ea7d02879d9da0da8d9d4933dee8ee86a8b460", size = 1990353, upload-time = "2025-11-04T13:42:33.111Z" },
-    { url = "https://files.pythonhosted.org/packages/44/8a/a98aede18db6e9cd5d66bcacd8a409fcf8134204cdede2e7de35c5a2c5ef/pydantic_core-2.41.5-cp39-cp39-win_amd64.whl", hash = "sha256:e4f4a984405e91527a0d62649ee21138f8e3d0ef103be488c1dc11a80d7f184b", size = 2015698, upload-time = "2025-11-04T13:42:35.484Z" },
     { url = "https://files.pythonhosted.org/packages/11/72/90fda5ee3b97e51c494938a4a44c3a35a9c96c19bba12372fb9c634d6f57/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:b96d5f26b05d03cc60f11a7761a5ded1741da411e7fe0909e27a5e6a0cb7b034", size = 2115441, upload-time = "2025-11-04T13:42:39.557Z" },
     { url = "https://files.pythonhosted.org/packages/1f/53/8942f884fa33f50794f119012dc6a1a02ac43a56407adaac20463df8e98f/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:634e8609e89ceecea15e2d61bc9ac3718caaaa71963717bf3c8f38bfde64242c", size = 1930291, upload-time = "2025-11-04T13:42:42.169Z" },
     { url = "https://files.pythonhosted.org/packages/79/c8/ecb9ed9cd942bce09fc888ee960b52654fbdbede4ba6c2d6e0d3b1d8b49c/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:93e8740d7503eb008aa2df04d3b9735f845d43ae845e6dcd2be0b55a2da43cd2", size = 1948632, upload-time = "2025-11-04T13:42:44.564Z" },
@@ -303,14 +274,13 @@ wheels = [
 
 [[package]]
 name = "raccoontools"
-version = "1.3.1"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },
     { name = "raccoon-simple-stopwatch" },
     { name = "requests" },
     { name = "simple-log-factory" },
-    { name = "typing-extensions" },
     { name = "urllib3" },
 ]
 
@@ -318,15 +288,14 @@ dependencies = [
 requires-dist = [
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "raccoon-simple-stopwatch", specifier = "==0.0.3" },
-    { name = "requests", specifier = ">=2.32.5" },
+    { name = "requests", specifier = ">=2.33.1" },
     { name = "simple-log-factory", specifier = "==1.0.0" },
-    { name = "typing-extensions", specifier = "==4.15.0" },
     { name = "urllib3", specifier = ">=2.6.3" },
 ]
 
 [[package]]
 name = "requests"
-version = "2.32.5"
+version = "2.33.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -334,9 +303,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## [2.0.0]
### Breaking changes
- Dropped Python 3.9 support. Minimum required version is now Python 3.10.

### General
- Modernized type hints across the codebase: replaced `Union`, `Optional`, `List`, `Dict`, `Tuple`, and `Type` from `typing` with PEP 604 (`X | Y`) and PEP 585 (`list`, `dict`, `tuple`, `type`) syntax.
- Replaced `datetime.UTC` compatibility shim (`try/except ImportError`) with direct `timezone.utc` usage.
- Updated CI pipeline to test Python 3.10–3.15 (removed 3.9).
- Updated PyPI classifiers to reflect supported Python versions (3.10–3.14).
- Removed `typing-extensions` as a direct dependency (replaced `typing_extensions.TypedDict` with `typing.TypedDict`, available since Python 3.8).
- Updated `requests` and `urllib3` dependency versions to address security vulnerabilities.

### Added
- `get_date_based_subfolder`: New utility to create/get date-based subdirectories with configurable format, UTC support, and delta offsets.
