### PR TITLE
[raccoontools] New Version: 3.1.0

### DIFF
--- a/raccoontools-db/uv.lock
+++ b/raccoontools-db/uv.lock
@@ -595,7 +595,7 @@ otel = [
 
 [package.metadata]
 requires-dist = [
-    { name = "psycopg", extras = ["binary", "pool"], specifier = "==3.3.4" },
+    { name = "psycopg", extras = ["binary", "pool"], specifier = "~=3.3.4" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
     { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.12" },

--- a/raccoontools/CHANGELOG.md
+++ b/raccoontools/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## [3.1.0]
+
+### Added
+- `timestamp_to_datetime`: New converter that turns numeric timestamps (seconds, milliseconds, microseconds, or nanoseconds) into timezone-aware `datetime` objects. Uses integer arithmetic for `int` inputs to avoid IEEE-754 float rounding. Defaults to milliseconds and UTC.
+
 ## [3.0.0]
 Dropped support for Python 3.10. Minimum required version is now Python 3.11.
 

--- a/raccoontools/README.md
+++ b/raccoontools/README.md
@@ -195,6 +195,39 @@ for sentence in sentence_generator(2, min_length=40, max_length=80):
     print(sentence)
 ```
 
+## Converters
+
+### `timestamp_to_datetime`
+Converts a numeric timestamp to a timezone-aware `datetime` object. Uses integer arithmetic for `int` inputs to
+preserve full microsecond precision without IEEE-754 float rounding.
+
+**Parameters:**
+- `timestamp`: The numeric timestamp value (`int` or `float`).
+- `unit`: Unit of the input: `"s"`, `"ms"`, `"us"`, or `"ns"` (default: `"ms"`).
+- `tz`: Target timezone (default: `timezone.utc`). Pass `None` to get a naive datetime.
+
+**Example:**
+```python
+from raccoontools.converters.datetime_converters import timestamp_to_datetime
+
+# Milliseconds (default) — e.g. Nightscout, JavaScript Date.now()
+dt = timestamp_to_datetime(1_700_000_000_000)
+print(dt)  # 2023-11-14 22:13:20+00:00
+
+# Seconds
+dt = timestamp_to_datetime(1_700_000_000, unit="s")
+
+# Nanoseconds — sub-microsecond part is truncated
+dt = timestamp_to_datetime(1_700_000_000_123_456_789, unit="ns")
+print(dt.microsecond)  # 123456
+
+# Custom timezone
+from datetime import timezone, timedelta
+tz_ist = timezone(timedelta(hours=5, minutes=30))
+dt = timestamp_to_datetime(1_700_000_000_000, tz=tz_ist)
+print(dt)  # 2023-11-15 03:43:20+05:30
+```
+
 ## Shared Utilities
 
 ### `file_ops`

--- a/raccoontools/pyproject.toml
+++ b/raccoontools/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "raccoontools"
-version = "3.0.0"
+version = "3.1.0"
 description = "A collection of tools, and helpers that I usually want for a handful of projects, so to avoid rewriting them every time, I decided to create this package."
 readme = "README.md"
 license = { file = "LICENSE.txt" }
@@ -24,6 +24,9 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
+
+requires-python = ">=3.11"
+
 dependencies = [
     "raccoon-simple-stopwatch==0.0.3",
     "simple-log-factory==1.0.0",
@@ -35,7 +38,13 @@ dependencies = [
     # https://github.com/brenordv/pypi-raccoon-tools/security/dependabot/3
     "urllib3==2.7.0"
 ]
-requires-python = ">=3.11"
+
+[dependency-groups]
+dev = [
+    "pytest==9.0.3",
+]
+
+
 
 [project.urls]
 "Homepage" = "https://github.com/brenordv/pypi-raccoon-tools"

--- a/raccoontools/raccoontools/converters/datetime_converters.py
+++ b/raccoontools/raccoontools/converters/datetime_converters.py
@@ -1,0 +1,88 @@
+import math
+from datetime import datetime, timedelta, timezone, tzinfo
+
+EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
+
+_VALID_UNITS = frozenset({"s", "ms", "us", "ns"})
+
+_INT_UNIT_TO_MICROSECONDS = {
+    "s": (1_000_000, 1),
+    "ms": (1_000, 1),
+    "us": (1, 1),
+    "ns": (1, 1_000),
+}
+
+_FLOAT_UNIT_TO_SECONDS_DIVISOR = {
+    "s": 1,
+    "ms": 1_000,
+    "us": 1_000_000,
+    "ns": 1_000_000_000,
+}
+
+
+def timestamp_to_datetime(
+    timestamp: int | float,
+    unit: str = "ms",
+    tz: tzinfo | None = timezone.utc,
+) -> datetime:
+    """
+    Convert a numeric timestamp to a datetime object.
+
+    Uses integer arithmetic when the input is an int to avoid IEEE-754
+    float rounding. Falls back to ``datetime.fromtimestamp`` for float inputs.
+
+    Args:
+        timestamp (int | float): The numeric timestamp value to convert.
+        unit (str): Unit of the input: ``"s"``, ``"ms"``, ``"us"``, or ``"ns"``.
+            Default is ``"ms"``.
+        tz (tzinfo | None): Target timezone. Defaults to ``timezone.utc``.
+            Pass ``None`` to get a naive datetime (discouraged).
+
+    Returns:
+        datetime: Timezone-aware datetime by default (UTC).
+
+    Raises:
+        ValueError: If ``unit`` is not one of the recognized values or if
+            ``timestamp`` is not finite.
+
+    Example:
+        >>> from raccoontools.converters.datetime_converters import timestamp_to_datetime
+        >>> dt = timestamp_to_datetime(1_700_000_000_000)
+        >>> dt.year, dt.month, dt.day
+        (2023, 11, 14)
+    """
+    if unit not in _VALID_UNITS:
+        raise ValueError(
+            f"Invalid unit '{unit}'. Must be one of: {', '.join(sorted(_VALID_UNITS))}."
+        )
+
+    if isinstance(timestamp, float) and not math.isfinite(timestamp):
+        raise ValueError(
+            f"Timestamp must be a finite number, got {timestamp}."
+        )
+
+    if isinstance(timestamp, int):
+        return _convert_int(timestamp, unit, tz)
+
+    return _convert_float(timestamp, unit, tz)
+
+
+def _convert_int(timestamp: int, unit: str, tz: tzinfo | None) -> datetime:
+    """Convert an integer timestamp using exact timedelta arithmetic."""
+    mul, div = _INT_UNIT_TO_MICROSECONDS[unit]
+    microseconds = timestamp * mul // div
+
+    result = EPOCH + timedelta(microseconds=microseconds)
+
+    if tz is not None and tz != timezone.utc:
+        result = result.astimezone(tz)
+    elif tz is None:
+        result = result.replace(tzinfo=None)
+
+    return result
+
+
+def _convert_float(timestamp: float, unit: str, tz: tzinfo | None) -> datetime:
+    """Convert a float timestamp via datetime.fromtimestamp."""
+    seconds = timestamp / _FLOAT_UNIT_TO_SECONDS_DIVISOR[unit]
+    return datetime.fromtimestamp(seconds, tz=tz)

--- a/raccoontools/tests/test_datetime_converters.py
+++ b/raccoontools/tests/test_datetime_converters.py
@@ -1,0 +1,131 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from raccoontools.converters.datetime_converters import (
+    EPOCH,
+    timestamp_to_datetime,
+)
+
+UTC = timezone.utc
+
+
+class TestTimestampToDatetimeMilliseconds:
+    def test_epoch_zero(self):
+        result = timestamp_to_datetime(0)
+        assert result == datetime(1970, 1, 1, tzinfo=UTC)
+
+    def test_known_nightscout_timestamp(self):
+        result = timestamp_to_datetime(1_700_000_000_000)
+        assert result == datetime(2023, 11, 14, 22, 13, 20, tzinfo=UTC)
+
+    def test_negative_timestamp_before_epoch(self):
+        result = timestamp_to_datetime(-86_400_000)
+        assert result == datetime(1969, 12, 31, tzinfo=UTC)
+
+    def test_millisecond_precision_preserved(self):
+        result = timestamp_to_datetime(1_700_000_000_123)
+        assert result.microsecond == 123_000
+
+    def test_large_future_timestamp(self):
+        result = timestamp_to_datetime(32_503_680_000_000)
+        assert result == datetime(3000, 1, 1, tzinfo=UTC)
+
+
+class TestTimestampToDatetimeUnits:
+    def test_seconds_int(self):
+        result = timestamp_to_datetime(1_700_000_000, unit="s")
+        assert result == datetime(2023, 11, 14, 22, 13, 20, tzinfo=UTC)
+
+    def test_seconds_float(self):
+        result = timestamp_to_datetime(1_700_000_000.123, unit="s")
+        assert abs(result.microsecond - 123_000) <= 1
+
+    def test_microseconds(self):
+        result = timestamp_to_datetime(1_700_000_000_000_000, unit="us")
+        assert result == datetime(2023, 11, 14, 22, 13, 20, tzinfo=UTC)
+
+    def test_microseconds_with_precision(self):
+        result = timestamp_to_datetime(1_700_000_000_123_456, unit="us")
+        assert result.microsecond == 123_456
+
+    def test_nanoseconds(self):
+        result = timestamp_to_datetime(1_700_000_000_000_000_000, unit="ns")
+        assert result == datetime(2023, 11, 14, 22, 13, 20, tzinfo=UTC)
+
+    def test_nanoseconds_truncates_sub_microsecond(self):
+        result = timestamp_to_datetime(1_700_000_000_123_456_789, unit="ns")
+        assert result.microsecond == 123_456
+
+
+class TestTimestampToDatetimeTimezone:
+    def test_default_is_utc(self):
+        result = timestamp_to_datetime(0)
+        assert result.tzinfo == UTC
+
+    def test_explicit_utc(self):
+        result = timestamp_to_datetime(0, tz=UTC)
+        assert result == timestamp_to_datetime(0)
+
+    def test_fixed_offset_positive(self):
+        tz_ist = timezone(timedelta(hours=5, minutes=30))
+        result = timestamp_to_datetime(0, tz=tz_ist)
+        assert result.hour == 5
+        assert result.minute == 30
+
+    def test_fixed_offset_negative(self):
+        tz_minus3 = timezone(timedelta(hours=-3))
+        result = timestamp_to_datetime(0, tz=tz_minus3)
+        assert result.day == 31
+        assert result.hour == 21
+
+    def test_naive_datetime_when_tz_none(self):
+        result = timestamp_to_datetime(0, tz=None)
+        assert result.tzinfo is None
+
+
+class TestTimestampToDatetimeIntVsFloat:
+    def test_int_path_exact_microseconds(self):
+        result = timestamp_to_datetime(1_700_000_000_123)
+        assert result.microsecond == 123_000
+
+    def test_float_seconds_reasonable_precision(self):
+        result = timestamp_to_datetime(1_700_000_000.123456, unit="s")
+        assert abs(result.microsecond - 123_456) <= 1
+
+    def test_int_and_float_equivalent_for_round_values(self):
+        int_result = timestamp_to_datetime(1_700_000_000_000)
+        float_result = timestamp_to_datetime(1_700_000_000.0, unit="s")
+        assert int_result == float_result
+
+
+class TestTimestampToDatetimeValidation:
+    def test_invalid_unit_raises_valueerror(self):
+        with pytest.raises(ValueError, match="Invalid unit"):
+            timestamp_to_datetime(0, unit="hours")
+
+    def test_nan_raises_valueerror(self):
+        with pytest.raises(ValueError, match="finite"):
+            timestamp_to_datetime(float("nan"))
+
+    def test_inf_raises_valueerror(self):
+        with pytest.raises(ValueError, match="finite"):
+            timestamp_to_datetime(float("inf"))
+
+    def test_negative_inf_raises_valueerror(self):
+        with pytest.raises(ValueError, match="finite"):
+            timestamp_to_datetime(float("-inf"))
+
+
+class TestEpochConstant:
+    def test_epoch_is_utc_aware(self):
+        assert EPOCH.tzinfo == UTC
+
+    def test_epoch_is_1970(self):
+        assert EPOCH.year == 1970
+        assert EPOCH.month == 1
+        assert EPOCH.day == 1
+        assert EPOCH.hour == 0
+        assert EPOCH.minute == 0
+        assert EPOCH.second == 0
+        assert EPOCH.microsecond == 0

--- a/raccoontools/uv.lock
+++ b/raccoontools/uv.lock
@@ -110,12 +110,48 @@ wheels = [
 ]
 
 [[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.13"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -236,6 +272,31 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
 name = "pytz"
 version = "2026.2"
 source = { registry = "https://pypi.org/simple" }
@@ -258,7 +319,7 @@ wheels = [
 
 [[package]]
 name = "raccoontools"
-version = "3.0.0"
+version = "3.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },
@@ -266,6 +327,11 @@ dependencies = [
     { name = "requests" },
     { name = "simple-log-factory" },
     { name = "urllib3" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
 ]
 
 [package.metadata]
@@ -276,6 +342,9 @@ requires-dist = [
     { name = "simple-log-factory", specifier = "==1.0.0" },
     { name = "urllib3", specifier = "==2.7.0" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = "==9.0.3" }]
 
 [[package]]
 name = "requests"


### PR DESCRIPTION
Added `timestamp_to_datetime` utility for timestamp conversion to timezone-aware `datetime`. Included comprehensive tests, updated documentation, and bumped version to `3.1.0`.