### PR TITLE
New version: v3.3.0

### DIFF
--- a/raccoontools/CHANGELOG.md
+++ b/raccoontools/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [3.3.0]
+
+### Added
+- `timedelta_to_readable_elapsed_time`: New converter that formats a `timedelta` as a human-readable elapsed time string (e.g. `"2 days and 5 hours ago"`). Supports configurable suffix, zero-delta label, and a `zero_delta_threshold` parameter to control when seconds-level detail is shown vs. returning a label like `"just now"`.
+- `time_value_to_readable_elapsed_time`: Convenience wrapper that accepts a numeric value and unit (e.g. `3600, "seconds"` or `2, "days"`) and delegates to `timedelta_to_readable_elapsed_time`.
+
 ## [3.2.1]
 - Re-added `"urllib3==2.7.0"` to solve security vulnerabilities. Package actually used by `requests`.
 - Updated `requests` to `2.24.1`.

--- a/raccoontools/README.md
+++ b/raccoontools/README.md
@@ -228,6 +228,66 @@ dt = timestamp_to_datetime(1_700_000_000_000, tz=tz_ist)
 print(dt)  # 2023-11-15 03:43:20+05:30
 ```
 
+### `timedelta_to_readable_elapsed_time`
+Converts a `timedelta` to a human-readable elapsed time string (e.g. `"2 days and 5 hours ago"`).
+Uses approximate 30-day months and 365-day years.
+
+**Parameters:**
+- `delta`: The `timedelta` to format. Must be non-negative.
+- `suffix`: Text appended after the time string (default: `"ago"`). Pass `""` or `None` to omit.
+- `zero_delta_label`: Returned when the delta is below `zero_delta_threshold` (default: `"just now"`).
+- `zero_delta_threshold`: Deltas below this value return `zero_delta_label` (default: `timedelta(seconds=60)`). Pass `None` to always show the real representation (e.g. `"30 seconds ago"`).
+
+**Example:**
+```python
+from datetime import timedelta
+from raccoontools.converters.datetime_converters import timedelta_to_readable_elapsed_time
+
+print(timedelta_to_readable_elapsed_time(timedelta(days=400)))
+# '1 year, 1 month and 5 days ago'
+
+print(timedelta_to_readable_elapsed_time(timedelta(hours=1, minutes=30)))
+# '1 hour and 30 minutes ago'
+
+print(timedelta_to_readable_elapsed_time(timedelta(seconds=10)))
+# 'just now'
+
+# Show seconds instead of "just now"
+print(timedelta_to_readable_elapsed_time(timedelta(seconds=30), zero_delta_threshold=None))
+# '30 seconds ago'
+
+print(timedelta_to_readable_elapsed_time(timedelta(hours=2), suffix="elapsed"))
+# '2 hours elapsed'
+
+print(timedelta_to_readable_elapsed_time(timedelta(hours=2), suffix=None))
+# '2 hours'
+```
+
+### `time_value_to_readable_elapsed_time`
+Convenience wrapper that converts a numeric value + unit into a `timedelta` and delegates
+to `timedelta_to_readable_elapsed_time`.
+
+**Parameters:**
+- `value`: The numeric amount (`int` or `float`). Must be non-negative and finite.
+- `time_piece`: Unit — one of `"milliseconds"`, `"seconds"`, `"minutes"`, `"hours"`, `"days"`, `"weeks"` (default: `"seconds"`).
+- `suffix`: Text appended after the time string (default: `"ago"`).
+- `zero_delta_label`: Returned when the resulting delta is below `zero_delta_threshold` (default: `"just now"`).
+- `zero_delta_threshold`: Deltas below this value return `zero_delta_label` (default: `timedelta(seconds=60)`). Pass `None` to always show the real representation.
+
+**Example:**
+```python
+from raccoontools.converters.datetime_converters import time_value_to_readable_elapsed_time
+
+print(time_value_to_readable_elapsed_time(3600))
+# '1 hour ago'
+
+print(time_value_to_readable_elapsed_time(2, time_piece="days"))
+# '2 days ago'
+
+print(time_value_to_readable_elapsed_time(1.5, time_piece="hours"))
+# '1 hour and 30 minutes ago'
+```
+
 ## Shared Utilities
 
 ### `file_ops`

--- a/raccoontools/pyproject.toml
+++ b/raccoontools/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "raccoontools"
-version = "3.2.1"
+version = "3.3.0"
 description = "A collection of tools, and helpers that I usually want for a handful of projects, so to avoid rewriting them every time, I decided to create this package."
 readme = "README.md"
 license = { file = "LICENSE.txt" }

--- a/raccoontools/raccoontools/converters/datetime_converters.py
+++ b/raccoontools/raccoontools/converters/datetime_converters.py
@@ -5,6 +5,10 @@ EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
 
 _VALID_UNITS = frozenset({"s", "ms", "us", "ns"})
 
+_VALID_TIME_PIECES = frozenset({
+    "milliseconds", "seconds", "minutes", "hours", "days", "weeks",
+})
+
 _INT_UNIT_TO_MICROSECONDS = {
     "s": (1_000_000, 1),
     "ms": (1_000, 1),
@@ -29,21 +33,20 @@ def timestamp_to_datetime(
     Convert a numeric timestamp to a datetime object.
 
     Uses integer arithmetic when the input is an int to avoid IEEE-754
-    float rounding. Falls back to ``datetime.fromtimestamp`` for float inputs.
+    float rounding. Falls back to "datetime.fromtimestamp" for float inputs.
 
     Args:
         timestamp (int | float): The numeric timestamp value to convert.
-        unit (str): Unit of the input: ``"s"``, ``"ms"``, ``"us"``, or ``"ns"``.
-            Default is ``"ms"``.
-        tz (tzinfo | None): Target timezone. Defaults to ``timezone.utc``.
-            Pass ``None`` to get a naive datetime (discouraged).
+        unit (str): Unit of the input: "s", "ms", "us", or "ns".
+            Default is "ms".
+        tz (tzinfo | None): Target timezone. Defaults to "timezone.utc".
+            Pass "None" to get a naive datetime (discouraged).
 
     Returns:
         datetime: Timezone-aware datetime by default (UTC).
 
     Raises:
-        ValueError: If ``unit`` is not one of the recognized values or if
-            ``timestamp`` is not finite.
+        ValueError: If "unit" is not one of the recognized values or if "timestamp" is not finite.
 
     Example:
         >>> from raccoontools.converters.datetime_converters import timestamp_to_datetime
@@ -86,3 +89,191 @@ def _convert_float(timestamp: float, unit: str, tz: tzinfo | None) -> datetime:
     """Convert a float timestamp via datetime.fromtimestamp."""
     seconds = timestamp / _FLOAT_UNIT_TO_SECONDS_DIVISOR[unit]
     return datetime.fromtimestamp(seconds, tz=tz)
+
+
+def _plural(count: int, unit: str) -> str:
+    """Return ``'count unit'`` with pluralization.
+
+    Examples:
+        >>> _plural(1, "year")
+        '1 year'
+        >>> _plural(2, "year")
+        '2 years'
+    """
+    return f"{count} {unit}" if count == 1 else f"{count} {unit}s"
+
+
+def _join_time_parts(parts: list[str]) -> str:
+    """Join time parts with commas and ``'and'`` before the last element.
+
+    Examples:
+        >>> _join_time_parts(["1 year"])
+        '1 year'
+        >>> _join_time_parts(["1 year", "2 months"])
+        '1 year and 2 months'
+        >>> _join_time_parts(["1 year", "2 months", "3 days"])
+        '1 year, 2 months and 3 days'
+    """
+    if len(parts) == 1:
+        return parts[0]
+    return f"{', '.join(parts[:-1])} and {parts[-1]}"
+
+
+def timedelta_to_readable_elapsed_time(
+    delta: timedelta,
+    suffix: str | None = "ago",
+    zero_delta_label: str = "just now",
+    zero_delta_threshold: timedelta | None = timedelta(seconds=60),
+) -> str:
+    """Convert a timedelta to a human-readable elapsed time string.
+
+    Uses approximate month (30 days) and year (365 days) lengths.
+
+    Args:
+        delta: The time difference to format. Must be non-negative.
+        suffix: Text appended after the time string (default: ``"ago"``).
+            A space is inserted automatically. Pass ``""`` or ``None``
+            to omit.
+        zero_delta_label: Returned when the delta falls below *zero_delta_threshold* (default: ``"just now"``).
+            The suffix is **not** appended to this label.
+        zero_delta_threshold: Deltas below this value return
+            *zero_delta_label* (default: ``timedelta(seconds=60)``).
+            Pass ``None`` to always show the real representation
+            (e.g. ``"30 seconds ago"`` instead of ``"just now"``).
+
+    Returns:
+        A string like ``"2 years, 3 months and 5 days ago"`` or
+        ``"just now"``.
+
+    Raises:
+        ValueError: If *delta* is negative.
+
+    Example:
+        >>> from datetime import timedelta
+        >>> timedelta_to_readable_elapsed_time(timedelta(days=400))
+        '1 year, 1 month and 5 days ago'
+        >>> timedelta_to_readable_elapsed_time(timedelta(seconds=30))
+        'just now'
+        >>> timedelta_to_readable_elapsed_time(
+        ...     timedelta(seconds=30), zero_delta_threshold=None,
+        ... )
+        '30 seconds ago'
+    """
+    if delta < timedelta(0):
+        raise ValueError(
+            f"delta must be non-negative, got {delta!r}."
+        )
+
+    if zero_delta_threshold is not None and delta < zero_delta_threshold:
+        return zero_delta_label
+
+    def _format(text: str) -> str:
+        if suffix:
+            return f"{text} {suffix}"
+        return text
+
+    if delta.days >= 365:
+        years = delta.days // 365
+        remaining_days = delta.days % 365
+        months = remaining_days // 30
+        days = remaining_days % 30
+
+        parts = [_plural(years, "year")]
+        if months > 0:
+            parts.append(_plural(months, "month"))
+        if days > 0:
+            parts.append(_plural(days, "day"))
+        return _format(_join_time_parts(parts))
+
+    if delta.days >= 30:
+        months = delta.days // 30
+        days = delta.days % 30
+        parts = [_plural(months, "month")]
+        if days > 0:
+            parts.append(_plural(days, "day"))
+        return _format(_join_time_parts(parts))
+
+    if delta.days > 0:
+        parts = [_plural(delta.days, "day")]
+        hours = delta.seconds // 3600
+        if hours > 0:
+            parts.append(_plural(hours, "hour"))
+        return _format(_join_time_parts(parts))
+
+    if delta.seconds >= 3600:
+        hours = delta.seconds // 3600
+        minutes = (delta.seconds % 3600) // 60
+        parts = [_plural(hours, "hour")]
+        if minutes > 0:
+            parts.append(_plural(minutes, "minute"))
+        return _format(_join_time_parts(parts))
+
+    if delta.seconds >= 60:
+        return _format(_plural(delta.seconds // 60, "minute"))
+
+    if delta.seconds > 0:
+        return _format(_plural(delta.seconds, "second"))
+
+    return zero_delta_label
+
+
+def time_value_to_readable_elapsed_time(
+    value: int | float,
+    time_piece: str = "seconds",
+    suffix: str | None = "ago",
+    zero_delta_label: str = "just now",
+    zero_delta_threshold: timedelta | None = timedelta(seconds=60),
+) -> str:
+    """Convert a numeric time value to a human-readable elapsed time string.
+
+    Convenience wrapper: builds a ``timedelta`` from *value* + *time_piece*,
+    then delegates to :func:`timedelta_to_readable_elapsed_time`.
+
+    Args:
+        value: The numeric amount (must be non-negative and finite).
+        time_piece: Unit — one of ``"milliseconds"``, ``"seconds"``,
+            ``"minutes"``, ``"hours"``, ``"days"``, ``"weeks"``
+            (default: ``"seconds"``).
+        suffix: Text appended after the time string (default: ``"ago"``).
+        zero_delta_label: Returned when the resulting delta falls at
+            or below *zero_delta_threshold* (default: ``"just now"``).
+        zero_delta_threshold: Deltas below this value return
+            *zero_delta_label* (default: ``timedelta(seconds=60)``).
+            Pass ``None`` to always show the real representation.
+
+    Returns:
+        A string like ``"1 hour ago"`` or ``"just now"``.
+
+    Raises:
+        ValueError: If *time_piece* is invalid, *value* is negative,
+            or *value* is non-finite.
+
+    Example:
+        >>> time_value_to_readable_elapsed_time(3600)
+        '1 hour ago'
+        >>> time_value_to_readable_elapsed_time(2, time_piece="days")
+        '2 days ago'
+    """
+    if time_piece not in _VALID_TIME_PIECES:
+        raise ValueError(
+            f"Invalid time_piece '{time_piece}'. "
+            f"Must be one of: {', '.join(sorted(_VALID_TIME_PIECES))}."
+        )
+
+    if isinstance(value, float) and not math.isfinite(value):
+        raise ValueError(
+            f"value must be a finite number, got {value}."
+        )
+
+    if value < 0:
+        raise ValueError(
+            f"value must be non-negative, got {value}."
+        )
+
+    delta = timedelta(**{time_piece: value})
+    return timedelta_to_readable_elapsed_time(
+        delta,
+        suffix=suffix,
+        zero_delta_label=zero_delta_label,
+        zero_delta_threshold=zero_delta_threshold,
+    )

--- a/raccoontools/tests/test_datetime_converters.py
+++ b/raccoontools/tests/test_datetime_converters.py
@@ -4,6 +4,10 @@ import pytest
 
 from raccoontools.converters.datetime_converters import (
     EPOCH,
+    _join_time_parts,
+    _plural,
+    time_value_to_readable_elapsed_time,
+    timedelta_to_readable_elapsed_time,
     timestamp_to_datetime,
 )
 
@@ -129,3 +133,402 @@ class TestEpochConstant:
         assert EPOCH.minute == 0
         assert EPOCH.second == 0
         assert EPOCH.microsecond == 0
+
+
+# --- _plural ---
+
+
+class TestPlural:
+    def test_singular(self):
+        assert _plural(1, "year") == "1 year"
+
+    def test_plural(self):
+        assert _plural(2, "year") == "2 years"
+
+    def test_zero_is_plural(self):
+        assert _plural(0, "day") == "0 days"
+
+    def test_large_number(self):
+        assert _plural(100, "minute") == "100 minutes"
+
+
+# --- _join_time_parts ---
+
+
+class TestJoinTimeParts:
+    def test_single_part(self):
+        assert _join_time_parts(["1 year"]) == "1 year"
+
+    def test_two_parts(self):
+        assert _join_time_parts(["1 year", "2 months"]) == "1 year and 2 months"
+
+    def test_three_parts(self):
+        result = _join_time_parts(["1 year", "2 months", "3 days"])
+        assert result == "1 year, 2 months and 3 days"
+
+    def test_four_parts(self):
+        result = _join_time_parts(["1 year", "2 months", "3 days", "4 hours"])
+        assert result == "1 year, 2 months, 3 days and 4 hours"
+
+
+# --- timedelta_to_readable_elapsed_time: years ---
+
+
+class TestTimedeltaToReadableYears:
+    def test_exactly_one_year(self):
+        result = timedelta_to_readable_elapsed_time(timedelta(days=365))
+        assert result == "1 year ago"
+
+    def test_two_years(self):
+        result = timedelta_to_readable_elapsed_time(timedelta(days=730))
+        assert result == "2 years ago"
+
+    def test_year_and_months(self):
+        result = timedelta_to_readable_elapsed_time(timedelta(days=365 + 60))
+        assert result == "1 year and 2 months ago"
+
+    def test_year_and_days(self):
+        result = timedelta_to_readable_elapsed_time(timedelta(days=365 + 5))
+        assert result == "1 year and 5 days ago"
+
+    def test_year_months_and_days(self):
+        result = timedelta_to_readable_elapsed_time(timedelta(days=400))
+        # 400 days = 1 year (365) + 35 remaining = 1 month (30) + 5 days
+        assert result == "1 year, 1 month and 5 days ago"
+
+    def test_multiple_years_months_days(self):
+        result = timedelta_to_readable_elapsed_time(timedelta(days=365 * 3 + 75))
+        # 75 remaining = 2 months (60) + 15 days
+        assert result == "3 years, 2 months and 15 days ago"
+
+
+# --- timedelta_to_readable_elapsed_time: months ---
+
+
+class TestTimedeltaToReadableMonths:
+    def test_exactly_one_month(self):
+        result = timedelta_to_readable_elapsed_time(timedelta(days=30))
+        assert result == "1 month ago"
+
+    def test_two_months(self):
+        result = timedelta_to_readable_elapsed_time(timedelta(days=60))
+        assert result == "2 months ago"
+
+    def test_month_and_days(self):
+        result = timedelta_to_readable_elapsed_time(timedelta(days=45))
+        assert result == "1 month and 15 days ago"
+
+    def test_eleven_months(self):
+        result = timedelta_to_readable_elapsed_time(timedelta(days=330))
+        assert result == "11 months ago"
+
+    def test_upper_boundary(self):
+        result = timedelta_to_readable_elapsed_time(timedelta(days=364))
+        # 364 = 12 months (360) + 4 days
+        assert result == "12 months and 4 days ago"
+
+
+# --- timedelta_to_readable_elapsed_time: days ---
+
+
+class TestTimedeltaToReadableDays:
+    def test_one_day(self):
+        result = timedelta_to_readable_elapsed_time(timedelta(days=1))
+        assert result == "1 day ago"
+
+    def test_multiple_days(self):
+        result = timedelta_to_readable_elapsed_time(timedelta(days=15))
+        assert result == "15 days ago"
+
+    def test_twenty_nine_days(self):
+        result = timedelta_to_readable_elapsed_time(timedelta(days=29))
+        assert result == "29 days ago"
+
+    def test_day_with_hours(self):
+        result = timedelta_to_readable_elapsed_time(
+            timedelta(days=2, hours=5)
+        )
+        assert result == "2 days and 5 hours ago"
+
+    def test_day_without_extra_hours(self):
+        result = timedelta_to_readable_elapsed_time(
+            timedelta(days=3, minutes=30)
+        )
+        assert result == "3 days ago"
+
+
+# --- timedelta_to_readable_elapsed_time: hours ---
+
+
+class TestTimedeltaToReadableHours:
+    def test_one_hour(self):
+        result = timedelta_to_readable_elapsed_time(timedelta(hours=1))
+        assert result == "1 hour ago"
+
+    def test_multiple_hours(self):
+        result = timedelta_to_readable_elapsed_time(timedelta(hours=5))
+        assert result == "5 hours ago"
+
+    def test_twenty_three_hours(self):
+        result = timedelta_to_readable_elapsed_time(timedelta(hours=23))
+        assert result == "23 hours ago"
+
+    def test_hour_with_minutes(self):
+        result = timedelta_to_readable_elapsed_time(
+            timedelta(hours=1, minutes=30)
+        )
+        assert result == "1 hour and 30 minutes ago"
+
+    def test_hours_without_extra_minutes(self):
+        result = timedelta_to_readable_elapsed_time(
+            timedelta(hours=2, seconds=45)
+        )
+        assert result == "2 hours ago"
+
+
+# --- timedelta_to_readable_elapsed_time: minutes ---
+
+
+class TestTimedeltaToReadableMinutes:
+    def test_one_minute(self):
+        result = timedelta_to_readable_elapsed_time(timedelta(minutes=1))
+        assert result == "1 minute ago"
+
+    def test_multiple_minutes(self):
+        result = timedelta_to_readable_elapsed_time(timedelta(minutes=45))
+        assert result == "45 minutes ago"
+
+    def test_fifty_nine_minutes(self):
+        result = timedelta_to_readable_elapsed_time(timedelta(minutes=59))
+        assert result == "59 minutes ago"
+
+
+# --- timedelta_to_readable_elapsed_time: zero/sub-minute ---
+
+
+class TestTimedeltaToReadableZeroDelta:
+    def test_zero_delta(self):
+        result = timedelta_to_readable_elapsed_time(timedelta(0))
+        assert result == "just now"
+
+    def test_one_second(self):
+        result = timedelta_to_readable_elapsed_time(timedelta(seconds=1))
+        assert result == "just now"
+
+    def test_fifty_nine_seconds(self):
+        result = timedelta_to_readable_elapsed_time(timedelta(seconds=59))
+        assert result == "just now"
+
+    def test_custom_zero_label(self):
+        result = timedelta_to_readable_elapsed_time(
+            timedelta(seconds=10), zero_delta_label="moments ago"
+        )
+        assert result == "moments ago"
+
+    def test_zero_label_has_no_suffix(self):
+        result = timedelta_to_readable_elapsed_time(
+            timedelta(0), suffix="ago"
+        )
+        assert result == "just now"
+
+
+# --- timedelta_to_readable_elapsed_time: suffix ---
+
+
+class TestTimedeltaToReadableSuffix:
+    def test_default_suffix(self):
+        result = timedelta_to_readable_elapsed_time(timedelta(hours=1))
+        assert result == "1 hour ago"
+
+    def test_custom_suffix(self):
+        result = timedelta_to_readable_elapsed_time(
+            timedelta(hours=1), suffix="elapsed"
+        )
+        assert result == "1 hour elapsed"
+
+    def test_empty_suffix(self):
+        result = timedelta_to_readable_elapsed_time(
+            timedelta(hours=1), suffix=""
+        )
+        assert result == "1 hour"
+
+    def test_none_suffix(self):
+        result = timedelta_to_readable_elapsed_time(
+            timedelta(hours=1), suffix=None
+        )
+        assert result == "1 hour"
+
+
+# --- timedelta_to_readable_elapsed_time: zero_delta_threshold ---
+
+
+class TestTimedeltaToReadableThreshold:
+    def test_default_threshold_hides_seconds(self):
+        result = timedelta_to_readable_elapsed_time(timedelta(seconds=30))
+        assert result == "just now"
+
+    def test_none_threshold_shows_seconds(self):
+        result = timedelta_to_readable_elapsed_time(
+            timedelta(seconds=30), zero_delta_threshold=None
+        )
+        assert result == "30 seconds ago"
+
+    def test_none_threshold_shows_one_second(self):
+        result = timedelta_to_readable_elapsed_time(
+            timedelta(seconds=1), zero_delta_threshold=None
+        )
+        assert result == "1 second ago"
+
+    def test_none_threshold_zero_delta_still_returns_label(self):
+        result = timedelta_to_readable_elapsed_time(
+            timedelta(0), zero_delta_threshold=None
+        )
+        assert result == "just now"
+
+    def test_custom_threshold_hides_below(self):
+        result = timedelta_to_readable_elapsed_time(
+            timedelta(seconds=90),
+            zero_delta_threshold=timedelta(minutes=5),
+        )
+        assert result == "just now"
+
+    def test_custom_threshold_shows_above(self):
+        result = timedelta_to_readable_elapsed_time(
+            timedelta(minutes=10),
+            zero_delta_threshold=timedelta(minutes=5),
+        )
+        assert result == "10 minutes ago"
+
+    def test_exact_threshold_boundary_shows_value(self):
+        result = timedelta_to_readable_elapsed_time(
+            timedelta(seconds=60),
+            zero_delta_threshold=timedelta(seconds=60),
+        )
+        assert result == "1 minute ago"
+
+    def test_none_threshold_with_custom_suffix(self):
+        result = timedelta_to_readable_elapsed_time(
+            timedelta(seconds=45),
+            suffix="elapsed",
+            zero_delta_threshold=None,
+        )
+        assert result == "45 seconds elapsed"
+
+    def test_none_threshold_with_no_suffix(self):
+        result = timedelta_to_readable_elapsed_time(
+            timedelta(seconds=10),
+            suffix=None,
+            zero_delta_threshold=None,
+        )
+        assert result == "10 seconds"
+
+    def test_wrapper_passes_threshold_none(self):
+        result = time_value_to_readable_elapsed_time(
+            30, zero_delta_threshold=None
+        )
+        assert result == "30 seconds ago"
+
+    def test_wrapper_passes_custom_threshold(self):
+        result = time_value_to_readable_elapsed_time(
+            90, zero_delta_threshold=timedelta(minutes=5)
+        )
+        assert result == "just now"
+
+
+# --- timedelta_to_readable_elapsed_time: validation ---
+
+
+class TestTimedeltaToReadableValidation:
+    def test_negative_delta_raises(self):
+        with pytest.raises(ValueError, match="non-negative"):
+            timedelta_to_readable_elapsed_time(timedelta(seconds=-1))
+
+    def test_large_negative_delta_raises(self):
+        with pytest.raises(ValueError, match="non-negative"):
+            timedelta_to_readable_elapsed_time(timedelta(days=-30))
+
+
+# --- time_value_to_readable_elapsed_time ---
+
+
+class TestTimeValueToReadable:
+    def test_seconds_default(self):
+        result = time_value_to_readable_elapsed_time(3600)
+        assert result == "1 hour ago"
+
+    def test_milliseconds(self):
+        result = time_value_to_readable_elapsed_time(
+            3_600_000, time_piece="milliseconds"
+        )
+        assert result == "1 hour ago"
+
+    def test_minutes(self):
+        result = time_value_to_readable_elapsed_time(
+            90, time_piece="minutes"
+        )
+        assert result == "1 hour and 30 minutes ago"
+
+    def test_hours(self):
+        result = time_value_to_readable_elapsed_time(
+            2, time_piece="hours"
+        )
+        assert result == "2 hours ago"
+
+    def test_days(self):
+        result = time_value_to_readable_elapsed_time(
+            7, time_piece="days"
+        )
+        assert result == "7 days ago"
+
+    def test_weeks(self):
+        result = time_value_to_readable_elapsed_time(
+            2, time_piece="weeks"
+        )
+        assert result == "14 days ago"
+
+    def test_float_value(self):
+        result = time_value_to_readable_elapsed_time(
+            1.5, time_piece="hours"
+        )
+        assert result == "1 hour and 30 minutes ago"
+
+    def test_zero_value(self):
+        result = time_value_to_readable_elapsed_time(0)
+        assert result == "just now"
+
+    def test_passes_suffix(self):
+        result = time_value_to_readable_elapsed_time(
+            3600, suffix="elapsed"
+        )
+        assert result == "1 hour elapsed"
+
+    def test_passes_zero_delta_label(self):
+        result = time_value_to_readable_elapsed_time(
+            0, zero_delta_label="now"
+        )
+        assert result == "now"
+
+
+# --- time_value_to_readable_elapsed_time: validation ---
+
+
+class TestTimeValueToReadableValidation:
+    def test_invalid_time_piece_raises(self):
+        with pytest.raises(ValueError, match="Invalid time_piece"):
+            time_value_to_readable_elapsed_time(1, time_piece="months")
+
+    def test_negative_value_raises(self):
+        with pytest.raises(ValueError, match="non-negative"):
+            time_value_to_readable_elapsed_time(-1)
+
+    def test_nan_raises(self):
+        with pytest.raises(ValueError, match="finite"):
+            time_value_to_readable_elapsed_time(float("nan"))
+
+    def test_inf_raises(self):
+        with pytest.raises(ValueError, match="finite"):
+            time_value_to_readable_elapsed_time(float("inf"))
+
+    def test_negative_inf_raises(self):
+        with pytest.raises(ValueError, match="finite"):
+            time_value_to_readable_elapsed_time(float("-inf"))


### PR DESCRIPTION
## [3.3.0]

### Added
- `timedelta_to_readable_elapsed_time`: New converter that formats a `timedelta` as a human-readable elapsed time string (e.g. `"2 days and 5 hours ago"`). Supports configurable suffix, zero-delta label, and a `zero_delta_threshold` parameter to control when seconds-level detail is shown vs. returning a label like `"just now"`.
- `time_value_to_readable_elapsed_time`: Convenience wrapper that accepts a numeric value and unit (e.g. `3600, "seconds"` or `2, "days"`) and delegates to `timedelta_to_readable_elapsed_time`.
