### PR TITLE
New Version: 3.3.1

### DIFF
--- a/raccoontools/CHANGELOG.md
+++ b/raccoontools/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [3.3.1]
+- Security update. Added `idna` as explicit dependency to address security vulnerabilities surfaced by the use of `requests`. Will remove as soon as `requests` catches up.
+
 ## [3.3.0]
 
 ### Added

--- a/raccoontools/pyproject.toml
+++ b/raccoontools/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "raccoontools"
-version = "3.3.0"
+version = "3.3.1"
 description = "A collection of tools, and helpers that I usually want for a handful of projects, so to avoid rewriting them every time, I decided to create this package."
 readme = "README.md"
 license = { file = "LICENSE.txt" }
@@ -30,12 +30,17 @@ requires-python = ">=3.11"
 dependencies = [
     "raccoon-simple-stopwatch==0.0.3",
     "simple-log-factory==1.0.0",
-    "requests~=2.34.1",
+    "requests~=2.34.2",
     "pydantic~=2.13.4",
     # Adding this dependency explicitly to solve security issues while requests doesn't catch up. Refs:
-    # https://github.com/brenordv/pypi-raccoon-tools/security/dependabot/8
-    # https://github.com/brenordv/pypi-raccoon-tools/security/dependabot/9
-    "urllib3==2.7.0"
+    # https://github.com/brenordv/pypi-raccoon-tools/security/dependabot/1
+    # https://github.com/brenordv/pypi-raccoon-tools/security/dependabot/2
+    "urllib3==2.7.0",
+
+    # Adding this dependency explicitly to solve security issues while requests doesn't catch up. Refs:
+    # https://github.com/brenordv/pypi-raccoon-tools/security/dependabot/5
+    # https://github.com/brenordv/pypi-raccoon-tools/security/dependabot/6
+    "idna==3.17"
 ]
 
 [dependency-groups]

--- a/raccoontools/uv.lock
+++ b/raccoontools/uv.lock
@@ -120,11 +120,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.13"
+version = "3.17"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/28/99c51f664567218d824af024c0251650fb27e4ca066df188dab0769c5b91/idna-3.17.tar.gz", hash = "sha256:5eb0cb53bc467c12eadcf6de83163ad8527cec9416f44b9b61b19caedad2b87f", size = 196048, upload-time = "2026-05-28T14:32:38.55Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+    { url = "https://files.pythonhosted.org/packages/de/a7/f76514cc40ad6234098ecdebda08732d75964776c51a42845b7da10649e2/idna-3.17-py3-none-any.whl", hash = "sha256:466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c", size = 65316, upload-time = "2026-05-28T14:32:37.035Z" },
 ]
 
 [[package]]
@@ -319,9 +319,10 @@ wheels = [
 
 [[package]]
 name = "raccoontools"
-version = "3.2.1"
+version = "3.3.1"
 source = { editable = "." }
 dependencies = [
+    { name = "idna" },
     { name = "pydantic" },
     { name = "raccoon-simple-stopwatch" },
     { name = "requests" },
@@ -336,9 +337,10 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "idna", specifier = "==3.17" },
     { name = "pydantic", specifier = "~=2.13.4" },
     { name = "raccoon-simple-stopwatch", specifier = "==0.0.3" },
-    { name = "requests", specifier = "~=2.34.1" },
+    { name = "requests", specifier = "~=2.34.2" },
     { name = "simple-log-factory", specifier = "==1.0.0" },
     { name = "urllib3", specifier = "==2.7.0" },
 ]
@@ -348,7 +350,7 @@ dev = [{ name = "pytest", specifier = "==9.0.3" }]
 
 [[package]]
 name = "requests"
-version = "2.34.1"
+version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -356,9 +358,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/24/36/7180e7f077c38108945dbbdf60fe04db681c3feb6e96419f8c6dc8723741/requests-2.34.1.tar.gz", hash = "sha256:0fc5669f2b69704449fe1552360bd2a73a54512dfd03e65529157f1513322beb", size = 142783, upload-time = "2026-05-13T19:20:24.662Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/5a/4a949d170476de3c04ac036b5466422fbcbf348a917d8042eedf2cac7d1b/requests-2.34.1-py3-none-any.whl", hash = "sha256:bf38a3ff993960d3dd819c08862c40b3c703306eb7c744fcd9f4ddbb95b548f0", size = 73085, upload-time = "2026-05-13T19:20:22.827Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## [3.3.1]
- Security update. Added `idna` as explicit dependency to address security vulnerabilities surfaced by the use of `requests`. Will remove as soon as `requests` catches up.
