### PR TITLE
New version: 3.4.0

### DIFF
--- a/raccoontools/CHANGELOG.md
+++ b/raccoontools/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.4.0]
+
+### Changed
+- `load_json_from_file` and `save_json_to_file` now accept a string path in addition to a `Path` for the file/folder argument. `save_json_to_file` raises `ValueError` if the target is an empty (or whitespace-only) string.
+- `get_date_based_subfolder` now accepts a string path in addition to a `Path` for `ref_path`.
+- Bumped `idna` to `3.18`. (Not directly used in the repo. Added to solve security vulnerabilities surfaced by the use of `requests`.)
+
 ## [3.3.1]
 - Security update. Added `idna` as explicit dependency to address security vulnerabilities surfaced by the use of `requests`. Will remove as soon as `requests` catches up.
 

--- a/raccoontools/README.md
+++ b/raccoontools/README.md
@@ -293,8 +293,8 @@ print(time_value_to_readable_elapsed_time(1.5, time_piece="hours"))
 ### `file_ops`
 Provides functions to load and save JSON data to and from files.
 
-- `load_json_from_file(file: Path, encoding: str = "utf-8", object_hook: Callable | None = obj_dump_deserializer) -> dict | list[dict]`: Loads a JSON file and returns the data as a dictionary or list of dictionaries. By default, uses `obj_dump_deserializer` to reconstruct types (datetime, int, float, Path). Pass `object_hook=None` for raw JSON parsing with no type coercion.
-- `save_json_to_file(data: dict | list[dict], target_file_or_folder: Path, dump_kwargs: dict | None = None, encoding: str = "utf-8") -> Path`: Saves a dictionary or list of dictionaries to a JSON file.
+- `load_json_from_file(file: Path | str, encoding: str = "utf-8", object_hook: Callable | None = obj_dump_deserializer) -> dict | list[dict]`: Loads a JSON file and returns the data as a dictionary or list of dictionaries. Accepts a `Path` or a string path. By default, uses `obj_dump_deserializer` to reconstruct types (datetime, int, float, Path). Pass `object_hook=None` for raw JSON parsing with no type coercion.
+- `save_json_to_file(data: dict | list[dict], target_file_or_folder: Path | str, dump_kwargs: dict | None = None, encoding: str = "utf-8") -> Path`: Saves a dictionary or list of dictionaries to a JSON file. Accepts a `Path` or a string path (an empty string raises `ValueError`).
 
 **Example:**
 ```python
@@ -313,7 +313,7 @@ print(saved_file, loaded_payload)
 Provides utility functions for file operations.
 
 - `get_filename_for_new_file(file_extension: str, prefix: str | None = None, add_current_datetime_as_format: str = "%Y%m%d%H%M%S%f", use_utc: bool = True, unique_identifier: str | bool = True, part_separator: str = "-", suffix: str | None = None) -> str`: Generates a unique filename for a new file.
-- `get_date_based_subfolder(ref_path: Path, use_utc: bool = True, date_ref: datetime | None = None, add_delta_days: int | None = None, date_format: str = "%Y-%m-%d", create_if_missing: bool = True) -> Path`: Gets (or creates) a date-based subfolder under the given path. If `ref_path` points to a file (or has a file extension), uses its parent directory as the base.
+- `get_date_based_subfolder(ref_path: Path | str, use_utc: bool = True, date_ref: datetime | None = None, add_delta_days: int | None = None, date_format: str = "%Y-%m-%d", create_if_missing: bool = True) -> Path`: Gets (or creates) a date-based subfolder under the given path. Accepts a `Path` or a string path. If `ref_path` points to a file (or has a file extension), uses its parent directory as the base.
 
 **Example:**
 ```python

--- a/raccoontools/pyproject.toml
+++ b/raccoontools/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "raccoontools"
-version = "3.3.1"
+version = "3.4.0"
 description = "A collection of tools, and helpers that I usually want for a handful of projects, so to avoid rewriting them every time, I decided to create this package."
 readme = "README.md"
 license = { file = "LICENSE.txt" }
@@ -40,7 +40,7 @@ dependencies = [
     # Adding this dependency explicitly to solve security issues while requests doesn't catch up. Refs:
     # https://github.com/brenordv/pypi-raccoon-tools/security/dependabot/5
     # https://github.com/brenordv/pypi-raccoon-tools/security/dependabot/6
-    "idna==3.17"
+    "idna==3.18"
 ]
 
 [dependency-groups]

--- a/raccoontools/raccoontools/shared/file_ops.py
+++ b/raccoontools/raccoontools/shared/file_ops.py
@@ -15,14 +15,14 @@ _JSON_DUMPS_PARAMS = {
 
 
 def load_json_from_file(
-        file: Path,
+        file: Path | str,
         encoding: str = "utf-8",
         object_hook: Callable | None = _USE_DEFAULT_HOOK,
 ) -> dict | list[dict]:
     """
     Loads a JSON file and returns the data as dict or List[dict].
 
-    :param file: The file to load.
+    :param file: The file to load, as a ``Path`` or a string path.
     :param encoding: The encoding of the file. (Default: utf-8)
     :param object_hook: A function to customize JSON object decoding. By default,
     uses ``obj_dump_deserializer`` which reconstructs datetime, int, float and Path
@@ -31,6 +31,8 @@ def load_json_from_file(
     :raises FileNotFoundError: If the file does not exist or cannot be accessed.
     :return: The data from the file.
     """
+    file = Path(file)
+
     if file.is_dir():
         raise ValueError("The file must be a file, not a directory.")
 
@@ -45,23 +47,28 @@ def load_json_from_file(
 
 def save_json_to_file(
         data: dict | list[dict],
-        target_file_or_folder: Path,
+        target_file_or_folder: Path | str,
         dump_kwargs: dict | None = None,
         encoding: str = "utf-8"
 ) -> Path:
     """
     Saves a dict or List[dict] to a JSON file.
     :param data: The data to save.
-    :param target_file_or_folder: The file or folder to save the data. If the value passed is a folder, will
-    automatically generate a unique (and sortable) filename.
+    :param target_file_or_folder: The file or folder to save the data, as a ``Path`` or a string path. If the value
+    passed is a folder, will automatically generate a unique (and sortable) filename.
     :param dump_kwargs: The kwargs to pass to the json.dump function. If you want to use the defaults values, you can
     pass an empty dictionary in this argument. (Default: indent=2, ensure_ascii=True)
     :param encoding: The encoding of the file. (Default: utf-8)
-    :raises ValueError: If data or target_file_or_folder is None.
+    :raises ValueError: If data or target_file_or_folder is None, or if target_file_or_folder is an empty string.
     :return: The file where the data was saved.
     """
     if any(arg is None for arg in [data, target_file_or_folder]):
         raise ValueError("Both data and target_file_or_folder must be informed.")
+
+    if isinstance(target_file_or_folder, str) and not target_file_or_folder.strip():
+        raise ValueError("target_file_or_folder cannot be an empty string.")
+
+    target_file_or_folder = Path(target_file_or_folder)
 
     if dump_kwargs is None:
         dump_kwargs = _JSON_DUMPS_PARAMS

--- a/raccoontools/raccoontools/shared/file_utils.py
+++ b/raccoontools/raccoontools/shared/file_utils.py
@@ -54,7 +54,7 @@ def get_filename_for_new_file(
 
 
 def get_date_based_subfolder(
-        ref_path: Path,
+        ref_path: Path | str,
         use_utc: bool = True,
         date_ref: datetime | None = None,
         add_delta_days: int | None = None,
@@ -64,8 +64,9 @@ def get_date_based_subfolder(
     """
     Gets a subfolder for the reference date. Using the specified date format (by default YYYY-MM-DD).
 
-    :param ref_path: Folder that will be used as the main folder. If a file is provided, will use the parent as the
-    base. Caveat: If the path is a folder that doesn't exist, and has a dot in its name (i.e: '~/projects/my.project.data'), we'll assume it's a file.
+    :param ref_path: Folder that will be used as the main folder, as a ``Path`` or a string path. If a file is
+    provided, will use the parent as the base. Caveat: If the path is a folder that doesn't exist, and has a dot in
+    its name (i.e: '~/projects/my.project.data'), we'll assume it's a file.
     :param use_utc: If True, will use the UTC timezone. Only has an effect if date_ref is None.
     :param date_ref: The date to use as the reference. If None, will use the current date.
     :param add_delta_days: If informed, will add the delta days to the date.
@@ -73,6 +74,8 @@ def get_date_based_subfolder(
     :param create_if_missing: If True, will create the folder if it doesn't exist. (Default: True)
     :return: The subfolder path.
     """
+    ref_path = Path(ref_path)
+
     base_path = ref_path.parent if ref_path.is_file() or ref_path.suffix != "" else ref_path
 
     if date_ref is not None:

--- a/raccoontools/tests/test_file_ops.py
+++ b/raccoontools/tests/test_file_ops.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 
 import pytest
 
@@ -21,14 +22,30 @@ class TestLoadJsonFromFile:
         assert isinstance(result, list)
         assert len(result) == 2
 
+    def test_loads_from_str_path(self, tmp_path):
+        file = tmp_path / "data.json"
+        file.write_text('{"key": "value"}', encoding="utf-8")
+
+        result = load_json_from_file(str(file))
+        assert result["key"] == "value"
+
     def test_raises_on_directory(self, tmp_path):
         with pytest.raises(ValueError, match="not a directory"):
             load_json_from_file(tmp_path)
+
+    def test_raises_on_directory_str_path(self, tmp_path):
+        with pytest.raises(ValueError, match="not a directory"):
+            load_json_from_file(str(tmp_path))
 
     def test_raises_on_missing_file(self, tmp_path):
         missing = tmp_path / "nope.json"
         with pytest.raises(FileNotFoundError):
             load_json_from_file(missing)
+
+    def test_raises_on_missing_file_str_path(self, tmp_path):
+        missing = tmp_path / "nope.json"
+        with pytest.raises(FileNotFoundError):
+            load_json_from_file(str(missing))
 
 
 class TestSaveJsonToFile:
@@ -51,9 +68,29 @@ class TestSaveJsonToFile:
         loaded = json.loads(file.read_text(encoding="utf-8"))
         assert len(loaded) == 2
 
+    def test_saves_dict_to_str_path(self, tmp_path):
+        file = tmp_path / "out.json"
+        data = {"name": "test", "value": 42}
+
+        result = save_json_to_file(data, str(file))
+        assert result == file
+        assert isinstance(result, Path)
+        assert file.exists()
+
+        loaded = json.loads(file.read_text(encoding="utf-8"))
+        assert loaded["name"] == "test"
+
     def test_auto_generates_filename_for_directory(self, tmp_path):
         data = {"key": "val"}
         result = save_json_to_file(data, tmp_path)
+
+        assert result.parent == tmp_path
+        assert result.suffix == ".json"
+        assert result.exists()
+
+    def test_auto_generates_filename_for_directory_str_path(self, tmp_path):
+        data = {"key": "val"}
+        result = save_json_to_file(data, str(tmp_path))
 
         assert result.parent == tmp_path
         assert result.suffix == ".json"
@@ -66,6 +103,11 @@ class TestSaveJsonToFile:
     def test_raises_on_none_target(self):
         with pytest.raises(ValueError, match="must be informed"):
             save_json_to_file({"a": 1}, None)
+
+    @pytest.mark.parametrize("empty_target", ["", "   "])
+    def test_raises_on_empty_str_target(self, empty_target):
+        with pytest.raises(ValueError, match="empty string"):
+            save_json_to_file({"a": 1}, empty_target)
 
     def test_custom_dump_kwargs(self, tmp_path):
         file = tmp_path / "compact.json"

--- a/raccoontools/tests/test_file_utils.py
+++ b/raccoontools/tests/test_file_utils.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+from pathlib import Path
 from unittest.mock import patch
 
 from raccoontools.shared.file_utils import (
@@ -219,3 +220,30 @@ class TestGetDateBasedSubfolder:
         )
         assert result.exists()
         assert result == base / "2025-01-01"
+
+    def test_accepts_str_path_for_folder(self, tmp_path):
+        date_ref = datetime(2025, 3, 15, tzinfo=timezone.utc)
+        result = get_date_based_subfolder(
+            str(tmp_path), date_ref=date_ref, create_if_missing=False
+        )
+        assert isinstance(result, Path)
+        assert result == tmp_path / "2025-03-15"
+
+    def test_str_path_to_file_uses_parent(self, tmp_path):
+        file_path = tmp_path / "some_file.txt"
+        file_path.write_text("data")
+        date_ref = datetime(2025, 7, 4, tzinfo=timezone.utc)
+
+        result = get_date_based_subfolder(
+            str(file_path), date_ref=date_ref, create_if_missing=False
+        )
+        assert result == tmp_path / "2025-07-04"
+
+    def test_str_path_nonexistent_with_extension_uses_parent(self, tmp_path):
+        fake_file = tmp_path / "output" / "report.json"
+        date_ref = datetime(2025, 7, 4, tzinfo=timezone.utc)
+
+        result = get_date_based_subfolder(
+            str(fake_file), date_ref=date_ref, create_if_missing=False
+        )
+        assert result == tmp_path / "output" / "2025-07-04"

--- a/raccoontools/uv.lock
+++ b/raccoontools/uv.lock
@@ -120,11 +120,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.17"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b9/28/99c51f664567218d824af024c0251650fb27e4ca066df188dab0769c5b91/idna-3.17.tar.gz", hash = "sha256:5eb0cb53bc467c12eadcf6de83163ad8527cec9416f44b9b61b19caedad2b87f", size = 196048, upload-time = "2026-05-28T14:32:38.55Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/a7/f76514cc40ad6234098ecdebda08732d75964776c51a42845b7da10649e2/idna-3.17-py3-none-any.whl", hash = "sha256:466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c", size = 65316, upload-time = "2026-05-28T14:32:37.035Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -319,7 +319,7 @@ wheels = [
 
 [[package]]
 name = "raccoontools"
-version = "3.3.1"
+version = "3.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "idna" },
@@ -337,7 +337,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "idna", specifier = "==3.17" },
+    { name = "idna", specifier = "==3.18" },
     { name = "pydantic", specifier = "~=2.13.4" },
     { name = "raccoon-simple-stopwatch", specifier = "==0.0.3" },
     { name = "requests", specifier = "~=2.34.2" },


### PR DESCRIPTION
### Changed
- `load_json_from_file` and `save_json_to_file` now accept a string path in addition to a `Path` for the file/folder argument. `save_json_to_file` raises `ValueError` if the target is an empty (or whitespace-only) string.
- `get_date_based_subfolder` now accepts a string path in addition to a `Path` for `ref_path`.
- Bumped `idna` to `3.18`. (Not directly used in the repo. Added to solve security vulnerabilities surfaced by the use of `requests`.)