### PR TITLE
New version: 3.5.0

### DIFF
--- a/raccoontools/CHANGELOG.md
+++ b/raccoontools/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [3.5.0]
+
+### Added
+- `string_utils.linefy`: New string helper that collapses a multi-line string into a single line. Removes all linebreaks, merges sequential whitespace runs into a single space, and trims the ends. Raises `TypeError` for non-string input.
+
 ## [3.4.0]
 
 ### Changed

--- a/raccoontools/README.md
+++ b/raccoontools/README.md
@@ -327,6 +327,19 @@ folder = get_date_based_subfolder(Path("output/data"), add_delta_days=-1)
 print(folder)  # output/data/2025-03-31
 ```
 
+### `string_utils`
+Provides utility functions for string manipulation.
+
+- `linefy(text: str) -> str`: Collapses a multi-line string into a single line. Removes all linebreaks, merges multiple sequential whitespace characters (spaces, tabs, newlines, etc.) into a single space, and trims leading and trailing whitespace. Raises `TypeError` if `text` is not a `str`.
+
+**Example:**
+```python
+from raccoontools.shared.string_utils import linefy
+
+messy = "  Hello\n\tworld  \n  again  "
+print(linefy(messy))  # Hello world again
+```
+
 ### `http`
 Provides utility functions for HTTP headers.
 

--- a/raccoontools/pyproject.toml
+++ b/raccoontools/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "raccoontools"
-version = "3.4.0"
+version = "3.5.0"
 description = "A collection of tools, and helpers that I usually want for a handful of projects, so to avoid rewriting them every time, I decided to create this package."
 readme = "README.md"
 license = { file = "LICENSE.txt" }
@@ -45,7 +45,7 @@ dependencies = [
 
 [dependency-groups]
 dev = [
-    "pytest==9.0.3",
+    "pytest==9.1.0",
 ]
 
 

--- a/raccoontools/raccoontools/shared/string_utils.py
+++ b/raccoontools/raccoontools/shared/string_utils.py
@@ -1,0 +1,21 @@
+def linefy(text: str) -> str:
+    """
+    Collapses a multi-line string into a single line.
+
+    Removes all linebreaks, merges multiple sequential whitespace characters
+    (spaces, tabs, newlines, etc.) into a single space, and trims leading and
+    trailing whitespace.
+
+    :param text: The text to collapse into a single line.
+    :return: The text with all whitespace runs collapsed into single spaces and
+    the ends trimmed. Returns an empty string if the input contains only
+    whitespace.
+
+    Example:
+        >>> linefy("  Hello\\n\\tworld  \\n  again  ")
+        'Hello world again'
+    """
+    if not isinstance(text, str):
+        raise TypeError(f"Expected a str, got {type(text).__name__}.")
+
+    return " ".join(text.split())

--- a/raccoontools/tests/test_string_utils.py
+++ b/raccoontools/tests/test_string_utils.py
@@ -1,0 +1,68 @@
+import pytest
+
+from raccoontools.shared.string_utils import linefy
+
+
+class TestLinefy:
+    def test_removes_linebreaks(self):
+        assert linefy("line one\nline two\nline three") == "line one line two line three"
+
+    def test_removes_carriage_returns(self):
+        assert linefy("line one\r\nline two") == "line one line two"
+
+    def test_collapses_multiple_spaces(self):
+        assert linefy("too     many      spaces") == "too many spaces"
+
+    def test_collapses_tabs(self):
+        assert linefy("tab\tseparated\tvalues") == "tab separated values"
+
+    def test_collapses_mixed_whitespace(self):
+        assert linefy("mixed \t \n  whitespace") == "mixed whitespace"
+
+    def test_trims_leading_whitespace(self):
+        assert linefy("   leading") == "leading"
+
+    def test_trims_trailing_whitespace(self):
+        assert linefy("trailing   ") == "trailing"
+
+    def test_trims_leading_and_trailing_whitespace(self):
+        assert linefy("  both sides  ") == "both sides"
+
+    def test_combined_scenario(self):
+        text = "  Hello\n\tworld  \n  again  "
+        assert linefy(text) == "Hello world again"
+
+    def test_combined_scenario_using_literal(self):
+        text = """Hello world\t\tafter tabs!
+        Ping?
+        
+        Pong!\t
+        """
+        assert linefy(text) == "Hello world after tabs! Ping? Pong!"
+
+    def test_already_clean_string_is_unchanged(self):
+        assert linefy("already clean") == "already clean"
+
+    def test_single_word(self):
+        assert linefy("word") == "word"
+
+    def test_empty_string_returns_empty(self):
+        assert linefy("") == ""
+
+    def test_whitespace_only_returns_empty(self):
+        assert linefy("   \n\t\r  ") == ""
+
+    def test_preserves_internal_word_characters(self):
+        assert linefy("don't\nbreak-this_word") == "don't break-this_word"
+
+    def test_unicode_whitespace_is_collapsed(self):
+        # Non-breaking space (\xa0) and other unicode spaces are whitespace to str.split().
+        assert linefy("a\xa0\xa0b") == "a b"
+
+    @pytest.mark.parametrize(
+        "value",
+        [None, 123, 4.5, ["a", "b"], {"a": 1}, b"bytes"],
+    )
+    def test_non_string_input_raises_type_error(self, value):
+        with pytest.raises(TypeError):
+            linefy(value)

--- a/raccoontools/uv.lock
+++ b/raccoontools/uv.lock
@@ -282,7 +282,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "9.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -291,9 +291,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/0e/b5858858d74958632c49b72cb25a3976ff9f632397626715be71c89d3971/pytest-9.1.0.tar.gz", hash = "sha256:41dd9148c08072446394cefd3d79701701335a9f4cae69ba92e39f6c7f5c061c", size = 1634181, upload-time = "2026-06-13T18:52:45.983Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl", hash = "sha256:8ebb0e7888bdf2bdfc602ec51f8f62d50200af37356c74e503c79a94f5c81f32", size = 386453, upload-time = "2026-06-13T18:52:44.045Z" },
 ]
 
 [[package]]
@@ -319,7 +319,7 @@ wheels = [
 
 [[package]]
 name = "raccoontools"
-version = "3.4.0"
+version = "3.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "idna" },
@@ -346,7 +346,7 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = "==9.0.3" }]
+dev = [{ name = "pytest", specifier = "==9.1.0" }]
 
 [[package]]
 name = "requests"


### PR DESCRIPTION
### Added
- `string_utils.linefy`: New string helper that collapses a multi-line string into a single line. Removes all linebreaks, merges sequential whitespace runs into a single space, and trims the ends. Raises `TypeError` for non-string input.