### PR TITLE
New version: 1.0.1

### DIFF
--- a/raccoontools-db/CHANGELOG.md
+++ b/raccoontools-db/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [1.0.1]
+- Security update. Added `idna` as explicit dependency to address security vulnerabilities surfaced by the use of `requests`. Will remove as soon as `requests` catches up.
 
 ## [1.0.0]
 - Initial version of the package

--- a/raccoontools-db/pyproject.toml
+++ b/raccoontools-db/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "raccoontools-db"
-version = "1.0.0"
+version = "1.0.1"
 description = "A collection of utilities to be used with databases."
 readme = "README.md"
 license = { file = "LICENSE.txt" }
@@ -27,6 +27,11 @@ classifiers = [
 dependencies = [
     "psycopg[binary,pool]~=3.3.4",
     "simple-log-factory==1.0.0",
+
+    # Adding this dependency explicitly to solve security issues while requests doesn't catch up. Refs:
+    # https://github.com/brenordv/pypi-raccoon-tools/security/dependabot/5
+    # https://github.com/brenordv/pypi-raccoon-tools/security/dependabot/6
+    "idna==3.18"
 ]
 requires-python = ">=3.11"
 

--- a/raccoontools-db/uv.lock
+++ b/raccoontools-db/uv.lock
@@ -188,11 +188,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.13"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -570,9 +570,10 @@ wheels = [
 
 [[package]]
 name = "raccoontools-db"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "." }
 dependencies = [
+    { name = "idna" },
     { name = "psycopg", extra = ["binary", "pool"] },
     { name = "simple-log-factory" },
 ]
@@ -595,6 +596,7 @@ otel = [
 
 [package.metadata]
 requires-dist = [
+    { name = "idna", specifier = "==3.18" },
     { name = "psycopg", extras = ["binary", "pool"], specifier = "~=3.3.4" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },


### PR DESCRIPTION
## [1.0.1]
- Security update. Added `idna` as explicit dependency to address security vulnerabilities surfaced by the use of `requests`. Will remove as soon as `requests` catches up.