### PR TITLE
New version: 3.6.0

### DIFF
--- a/raccoontools-db/pyproject.toml
+++ b/raccoontools-db/pyproject.toml
@@ -39,7 +39,11 @@ requires-python = ">=3.11"
 otel = ["simple-log-factory-ext-otel[psycopg]==1.5.0"]
 fastapi = ["simple-log-factory-ext-otel[fastapi]==1.5.0"]
 all = ["simple-log-factory-ext-otel[fastapi,psycopg]==1.5.0"]
-dev = ["pytest>=8.0", "pytest-mock>=3.12", "pytest-asyncio>=0.23"]
+dev = [
+    "pytest>=9.1.1",
+    "pytest-mock>=3.15.1",
+    "pytest-asyncio>=1.4.0"
+]
 
 [project.urls]
 "Homepage" = "https://github.com/brenordv/pypi-raccoon-tools"

--- a/raccoontools-db/uv.lock
+++ b/raccoontools-db/uv.lock
@@ -529,7 +529,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -538,22 +538,22 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
 name = "pytest-asyncio"
-version = "1.3.0"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
 ]
 
 [[package]]
@@ -598,9 +598,9 @@ otel = [
 requires-dist = [
     { name = "idna", specifier = "==3.18" },
     { name = "psycopg", extras = ["binary", "pool"], specifier = "~=3.3.4" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
-    { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.12" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.1.1" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.4.0" },
+    { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.15.1" },
     { name = "simple-log-factory", specifier = "==1.0.0" },
     { name = "simple-log-factory-ext-otel", extras = ["fastapi"], marker = "extra == 'fastapi'", specifier = "==1.5.0" },
     { name = "simple-log-factory-ext-otel", extras = ["fastapi", "psycopg"], marker = "extra == 'all'", specifier = "==1.5.0" },

--- a/raccoontools/CHANGELOG.md
+++ b/raccoontools/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [3.6.0]
+
+### Added
+- `comparators.dict_comparators`: New comparison helpers for dictionaries and lists of dictionaries.
+  - `dicts_are_equal` / `compare_dicts`: deep, key-order-independent dictionary comparison. `compare_dicts` returns a `DictComparison` named tuple with `are_equal` and a `DictDiff` (`added` / `removed` / `changed`) keyed by dotted paths (e.g. `"user.address.zip"`). Nested dictionaries are recursed into; every other value (including nested lists, `datetime`, and custom types) is compared as an opaque leaf.
+  - `dict_lists_are_equal` / `compare_dict_lists`: order-independent `list[dict]` comparison (the lists are treated as multisets, so duplicates are counted). `compare_dict_lists` returns a `DictListComparison` with `only_in_a` / `only_in_b`.
+  - The `*_are_equal` functions delegate to their `compare_*` counterparts, so the boolean and detailed results can never disagree. All functions raise `TypeError` for invalid input types.
+
 ## [3.5.0]
 
 ### Added

--- a/raccoontools/README.md
+++ b/raccoontools/README.md
@@ -288,6 +288,49 @@ print(time_value_to_readable_elapsed_time(1.5, time_piece="hours"))
 # '1 hour and 30 minutes ago'
 ```
 
+## Comparators
+
+### `dicts_are_equal` / `compare_dicts`
+Deeply compares two dictionaries, ignoring key order. Nested dictionaries are recursed into; every other
+value (nested lists, `datetime` objects, custom types, ...) is compared as an opaque leaf via `==`.
+
+- `dicts_are_equal(a: dict, b: dict) -> bool`: Returns `True` if the dictionaries are deeply equal.
+- `compare_dicts(a: dict, b: dict) -> DictComparison`: Returns a named tuple `(are_equal, differences)`. `differences` is a `DictDiff` with `added` / `removed` / `changed` maps, keyed by dotted paths (e.g. `"user.address.zip"`). Both raise `TypeError` for non-dict input.
+
+**Example:**
+```python
+from raccoontools.comparators.dict_comparators import dicts_are_equal, compare_dicts
+
+print(dicts_are_equal({"a": 1, "b": 2}, {"b": 2, "a": 1}))  # True
+
+result = compare_dicts(
+    {"name": "Ada", "role": "dev"},
+    {"name": "Ada", "role": "lead", "active": True},
+)
+print(result.are_equal)              # False
+print(result.differences.changed)    # {'role': ('dev', 'lead')}
+print(result.differences.added)      # {'active': True}
+```
+
+### `dict_lists_are_equal` / `compare_dict_lists`
+Compares two lists of dictionaries **ignoring their order**. The lists are treated as multisets, so
+duplicates are counted. Lists nested *inside* a dictionary remain order-sensitive.
+
+- `dict_lists_are_equal(a: list[dict], b: list[dict]) -> bool`: Returns `True` if both lists hold the same dictionaries in any order.
+- `compare_dict_lists(a: list[dict], b: list[dict]) -> DictListComparison`: Returns a named tuple `(are_equal, differences)`. `differences` is a `DictListDiff` with `only_in_a` / `only_in_b`. Both raise `TypeError` if an argument is not a list or an element is not a dict.
+
+**Example:**
+```python
+from raccoontools.comparators.dict_comparators import dict_lists_are_equal, compare_dict_lists
+
+print(dict_lists_are_equal([{"id": 1}, {"id": 2}], [{"id": 2}, {"id": 1}]))  # True
+
+result = compare_dict_lists([{"id": 1}, {"id": 2}], [{"id": 2}, {"id": 3}])
+print(result.are_equal)              # False
+print(result.differences.only_in_a)  # [{'id': 1}]
+print(result.differences.only_in_b)  # [{'id': 3}]
+```
+
 ## Shared Utilities
 
 ### `file_ops`

--- a/raccoontools/pyproject.toml
+++ b/raccoontools/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "raccoontools"
-version = "3.5.0"
+version = "3.6.0"
 description = "A collection of tools, and helpers that I usually want for a handful of projects, so to avoid rewriting them every time, I decided to create this package."
 readme = "README.md"
 license = { file = "LICENSE.txt" }
@@ -10,7 +10,7 @@ authors = [
 maintainers = [
     { name = "Breno RdV", email = "hello@raccoon.ninja" },
 ]
-keywords = ["retry", "decorator", "benchmark", "logging", "requests", "json", "file operations", "serialization", "http", "utilities", "tools", "helpers", "python"]
+keywords = ["retry", "decorator", "benchmark", "logging", "requests", "json", "file operations", "serialization", "http", "utilities", "tools", "helpers", "python", "comparison", "diff", "dict"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
@@ -45,7 +45,7 @@ dependencies = [
 
 [dependency-groups]
 dev = [
-    "pytest==9.1.0",
+    "pytest==9.1.1",
 ]
 
 

--- a/raccoontools/raccoontools/comparators/dict_comparators.py
+++ b/raccoontools/raccoontools/comparators/dict_comparators.py
@@ -1,0 +1,336 @@
+"""Utilities for comparing dictionaries and lists of dictionaries.
+
+These helpers complement Python's built-in ``==`` operator by also reporting
+*what* differs, in a streamlined and predictable structure.
+
+Two kinds of comparison are provided:
+
+* **Dict comparison** (``dicts_are_equal`` / ``compare_dicts``) performs a deep,
+  key-order-independent comparison. Nested dictionaries are recursed into;
+  every other value (including nested lists, ``datetime`` objects and custom
+  types) is compared as an opaque leaf via ``==``.
+* **List-of-dict comparison** (``dict_lists_are_equal`` / ``compare_dict_lists``)
+  compares two lists of dictionaries **ignoring their order** (the lists are
+  treated as multisets, so duplicates are accounted for).
+
+The ``*_are_equal`` functions delegate to their ``compare_*`` counterparts so
+the boolean and the detailed result can never disagree.
+"""
+
+from collections import Counter
+from collections.abc import Hashable
+from typing import Any, NamedTuple
+
+
+class DictDiff(NamedTuple):
+    """Differences between two dictionaries.
+
+    Each mapping is keyed by a dotted path to the differing key
+    (e.g. ``"user.address.zip"``). Non-string keys are rendered with ``str``.
+    """
+
+    added: dict[str, Any]
+    """Paths present only in ``b``, mapped to their value in ``b``."""
+
+    removed: dict[str, Any]
+    """Paths present only in ``a``, mapped to their value in ``a``."""
+
+    changed: dict[str, tuple[Any, Any]]
+    """Paths present in both, mapped to ``(value_in_a, value_in_b)``."""
+
+
+class DictComparison(NamedTuple):
+    """Result of :func:`compare_dicts`."""
+
+    are_equal: bool
+    differences: DictDiff
+
+
+class DictListDiff(NamedTuple):
+    """Differences between two lists of dictionaries (order-independent)."""
+
+    only_in_a: list[dict]
+    """Elements of ``a`` with no matching element left in ``b`` (a's order)."""
+
+    only_in_b: list[dict]
+    """Elements of ``b`` with no matching element left in ``a`` (b's order)."""
+
+
+class DictListComparison(NamedTuple):
+    """Result of :func:`compare_dict_lists`."""
+
+    are_equal: bool
+    differences: DictListDiff
+
+
+def _ensure_dict(value: Any, name: str) -> None:
+    """Raise ``TypeError`` if *value* is not a ``dict``."""
+    if not isinstance(value, dict):
+        raise TypeError(
+            f"Expected '{name}' to be a dict, got {type(value).__name__}."
+        )
+
+
+def _ensure_list_of_dicts(value: Any, name: str) -> None:
+    """Raise ``TypeError`` if *value* is not a ``list`` of ``dict`` items."""
+    if not isinstance(value, list):
+        raise TypeError(
+            f"Expected '{name}' to be a list, got {type(value).__name__}."
+        )
+
+    for index, item in enumerate(value):
+        if not isinstance(item, dict):
+            raise TypeError(
+                f"Expected every item in '{name}' to be a dict, but the item "
+                f"at index {index} is {type(item).__name__}."
+            )
+
+
+def _join_path(prefix: str, key: Any) -> str:
+    """Append *key* to a dotted *prefix*, coercing the key to ``str``."""
+    key_str = str(key)
+    return f"{prefix}.{key_str}" if prefix else key_str
+
+
+def _diff_dicts(a: dict, b: dict, prefix: str = "") -> DictDiff:
+    """Recursively diff two dictionaries into added/removed/changed maps.
+
+    Nested dictionaries are recursed into; any other pair of values is compared
+    with ``==`` and, when unequal, reported as a single ``changed`` entry.
+    """
+    added: dict[str, Any] = {}
+    removed: dict[str, Any] = {}
+    changed: dict[str, tuple[Any, Any]] = {}
+
+    for key, a_value in a.items():
+        path = _join_path(prefix, key)
+
+        if key not in b:
+            removed[path] = a_value
+            continue
+
+        b_value = b[key]
+
+        # Identity short-circuit: mirrors dict '==' (which checks 'is' first),
+        # so a value compared against itself is always equal (e.g. NaN).
+        if a_value is b_value:
+            continue
+
+        if isinstance(a_value, dict) and isinstance(b_value, dict):
+            nested = _diff_dicts(a_value, b_value, path)
+            added.update(nested.added)
+            removed.update(nested.removed)
+            changed.update(nested.changed)
+        elif a_value != b_value:
+            changed[path] = (a_value, b_value)
+
+    for key, b_value in b.items():
+        if key not in a:
+            added[_join_path(prefix, key)] = b_value
+
+    return DictDiff(added=added, removed=removed, changed=changed)
+
+
+def compare_dicts(a: dict, b: dict) -> DictComparison:
+    """Deeply compare two dictionaries and report their differences.
+
+    The comparison ignores key order and recurses into nested dictionaries.
+    Any other value (nested lists, ``datetime`` objects, custom types, ...) is
+    compared as an opaque leaf via ``==``.
+
+    Args:
+        a: The left-hand dictionary.
+        b: The right-hand dictionary.
+
+    Returns:
+        DictComparison: A named tuple ``(are_equal, differences)`` where
+        ``differences`` is a :class:`DictDiff`. The result is unpackable, so
+        ``are_equal, diff = compare_dicts(a, b)`` works.
+
+    Raises:
+        TypeError: If *a* or *b* is not a ``dict``.
+
+    Example:
+        >>> from raccoontools.comparators.dict_comparators import compare_dicts
+        >>> result = compare_dicts(
+        ...     {"name": "Ada", "role": "dev"},
+        ...     {"name": "Ada", "role": "lead", "active": True},
+        ... )
+        >>> result.are_equal
+        False
+        >>> result.differences.changed
+        {'role': ('dev', 'lead')}
+        >>> result.differences.added
+        {'active': True}
+    """
+    _ensure_dict(a, "a")
+    _ensure_dict(b, "b")
+
+    differences = _diff_dicts(a, b)
+    are_equal = not (differences.added or differences.removed or differences.changed)
+    return DictComparison(are_equal=are_equal, differences=differences)
+
+
+def dicts_are_equal(a: dict, b: dict) -> bool:
+    """Return ``True`` if two dictionaries are deeply equal.
+
+    Convenience wrapper over :func:`compare_dicts` that discards the detailed
+    diff. Key order is ignored and nested dictionaries are compared recursively.
+
+    Args:
+        a: The left-hand dictionary.
+        b: The right-hand dictionary.
+
+    Returns:
+        bool: ``True`` if the dictionaries are equal, ``False`` otherwise.
+
+    Raises:
+        TypeError: If *a* or *b* is not a ``dict``.
+
+    Example:
+        >>> from raccoontools.comparators.dict_comparators import dicts_are_equal
+        >>> dicts_are_equal({"a": 1, "b": 2}, {"b": 2, "a": 1})
+        True
+    """
+    return compare_dicts(a, b).are_equal
+
+
+def _freeze(value: Any) -> Hashable:
+    """Convert *value* into a stable, hashable, order-aware representation.
+
+    Containers are type-tagged so that, for example, a ``dict`` can never
+    collide with a ``list`` that happens to hold the same items. Dictionaries
+    and sets are frozen order-independently; lists and tuples preserve order.
+    Scalars are returned unchanged, which keeps ``==`` semantics (note that
+    ``1``, ``1.0`` and ``True`` therefore compare equal).
+
+    Raises:
+        TypeError: If *value* contains an unhashable leaf that is not one of
+            the recognized container types.
+    """
+    if isinstance(value, dict):
+        return ("__dict__", frozenset(
+            (_freeze(k), _freeze(v)) for k, v in value.items()
+        ))
+
+    if isinstance(value, (set, frozenset)):
+        return ("__set__", frozenset(_freeze(item) for item in value))
+
+    if isinstance(value, list):
+        return ("__list__", tuple(_freeze(item) for item in value))
+
+    if isinstance(value, tuple):
+        return ("__tuple__", tuple(_freeze(item) for item in value))
+
+    try:
+        hash(value)
+    except TypeError as exc:
+        raise TypeError(
+            f"Cannot compare lists containing an unhashable value of type "
+            f"{type(value).__name__}: {value!r}."
+        ) from exc
+
+    return value
+
+
+def _collect_surplus(
+    originals: list[dict],
+    frozen: list[Hashable],
+    surplus: Counter,
+) -> list[dict]:
+    """Return the original dicts that make up a multiset *surplus*.
+
+    Iterates *originals* in order, emitting each element while the surplus count
+    for its frozen key remains positive. This preserves the source order and
+    respects duplicate counts.
+    """
+    if not surplus:
+        return []
+
+    remaining = dict(surplus)
+    result: list[dict] = []
+    for original, key in zip(originals, frozen):
+        if remaining.get(key, 0) > 0:
+            result.append(original)
+            remaining[key] -= 1
+
+    return result
+
+
+def compare_dict_lists(a: list[dict], b: list[dict]) -> DictListComparison:
+    """Compare two lists of dictionaries, ignoring element order.
+
+    The lists are treated as multisets: order is irrelevant but duplicates are
+    counted. Each element is compared deeply (nested dicts, lists, ``datetime``,
+    etc.). The result lists the elements that could not be matched between the
+    two inputs.
+
+    Args:
+        a: The left-hand list of dictionaries.
+        b: The right-hand list of dictionaries.
+
+    Returns:
+        DictListComparison: A named tuple ``(are_equal, differences)`` where
+        ``differences`` is a :class:`DictListDiff`. ``only_in_a`` preserves the
+        order of *a*; ``only_in_b`` preserves the order of *b*.
+
+    Raises:
+        TypeError: If *a* or *b* is not a ``list``, if any element is not a
+            ``dict``, or if an element contains an unhashable leaf value.
+
+    Example:
+        >>> from raccoontools.comparators.dict_comparators import compare_dict_lists
+        >>> result = compare_dict_lists(
+        ...     [{"id": 1}, {"id": 2}],
+        ...     [{"id": 2}, {"id": 3}],
+        ... )
+        >>> result.are_equal
+        False
+        >>> result.differences.only_in_a
+        [{'id': 1}]
+        >>> result.differences.only_in_b
+        [{'id': 3}]
+    """
+    _ensure_list_of_dicts(a, "a")
+    _ensure_list_of_dicts(b, "b")
+
+    frozen_a = [_freeze(item) for item in a]
+    frozen_b = [_freeze(item) for item in b]
+
+    counter_a = Counter(frozen_a)
+    counter_b = Counter(frozen_b)
+
+    only_in_a = _collect_surplus(a, frozen_a, counter_a - counter_b)
+    only_in_b = _collect_surplus(b, frozen_b, counter_b - counter_a)
+
+    are_equal = not only_in_a and not only_in_b
+    return DictListComparison(
+        are_equal=are_equal,
+        differences=DictListDiff(only_in_a=only_in_a, only_in_b=only_in_b),
+    )
+
+
+def dict_lists_are_equal(a: list[dict], b: list[dict]) -> bool:
+    """Return ``True`` if two lists of dictionaries are equal, ignoring order.
+
+    Convenience wrapper over :func:`compare_dict_lists` that discards the
+    detailed diff. The lists are treated as multisets (duplicates counted).
+
+    Args:
+        a: The left-hand list of dictionaries.
+        b: The right-hand list of dictionaries.
+
+    Returns:
+        bool: ``True`` if the lists hold the same dictionaries (in any order),
+        ``False`` otherwise.
+
+    Raises:
+        TypeError: If *a* or *b* is not a ``list``, if any element is not a
+            ``dict``, or if an element contains an unhashable leaf value.
+
+    Example:
+        >>> from raccoontools.comparators.dict_comparators import dict_lists_are_equal
+        >>> dict_lists_are_equal([{"id": 1}, {"id": 2}], [{"id": 2}, {"id": 1}])
+        True
+    """
+    return compare_dict_lists(a, b).are_equal

--- a/raccoontools/tests/test_dict_comparators.py
+++ b/raccoontools/tests/test_dict_comparators.py
@@ -1,0 +1,337 @@
+from datetime import datetime
+
+import pytest
+
+from raccoontools.comparators.dict_comparators import (
+    DictComparison,
+    DictDiff,
+    DictListComparison,
+    DictListDiff,
+    compare_dict_lists,
+    compare_dicts,
+    dict_lists_are_equal,
+    dicts_are_equal,
+)
+
+
+# ---------------------------------------------------------------------------
+# dicts_are_equal
+# ---------------------------------------------------------------------------
+class TestDictsAreEqual:
+    def test_identical_flat_dicts(self):
+        assert dicts_are_equal({"a": 1, "b": 2}, {"a": 1, "b": 2})
+
+    def test_key_order_is_ignored(self):
+        assert dicts_are_equal({"a": 1, "b": 2}, {"b": 2, "a": 1})
+
+    def test_different_values(self):
+        assert not dicts_are_equal({"a": 1}, {"a": 2})
+
+    def test_missing_key(self):
+        assert not dicts_are_equal({"a": 1, "b": 2}, {"a": 1})
+
+    def test_extra_key(self):
+        assert not dicts_are_equal({"a": 1}, {"a": 1, "b": 2})
+
+    def test_empty_dicts_are_equal(self):
+        assert dicts_are_equal({}, {})
+
+    def test_nested_dicts_equal(self):
+        a = {"user": {"name": "Ada", "address": {"zip": "12345"}}}
+        b = {"user": {"address": {"zip": "12345"}, "name": "Ada"}}
+        assert dicts_are_equal(a, b)
+
+    def test_nested_dicts_unequal(self):
+        a = {"user": {"address": {"zip": "12345"}}}
+        b = {"user": {"address": {"zip": "54321"}}}
+        assert not dicts_are_equal(a, b)
+
+    def test_datetime_values_equal(self):
+        dt = datetime(2024, 1, 1, 12, 0, 0)
+        assert dicts_are_equal({"t": dt}, {"t": datetime(2024, 1, 1, 12, 0, 0)})
+
+    def test_datetime_values_unequal(self):
+        assert not dicts_are_equal(
+            {"t": datetime(2024, 1, 1)}, {"t": datetime(2024, 1, 2)}
+        )
+
+    def test_nested_list_order_is_significant(self):
+        # Lists nested inside dicts follow native '==' (order matters).
+        assert not dicts_are_equal({"items": [1, 2, 3]}, {"items": [3, 2, 1]})
+
+    def test_nested_list_equal_when_same_order(self):
+        assert dicts_are_equal({"items": [1, 2, 3]}, {"items": [1, 2, 3]})
+
+    def test_same_object_is_equal_to_itself(self):
+        d = {"x": float("nan")}
+        # Same object on both sides: identity short-circuit makes it equal,
+        # mirroring dict '==' even though NaN != NaN.
+        assert dicts_are_equal(d, d)
+
+
+# ---------------------------------------------------------------------------
+# compare_dicts
+# ---------------------------------------------------------------------------
+class TestCompareDicts:
+    def test_returns_dict_comparison_type(self):
+        result = compare_dicts({"a": 1}, {"a": 1})
+        assert isinstance(result, DictComparison)
+        assert isinstance(result.differences, DictDiff)
+
+    def test_equal_dicts_have_empty_diff(self):
+        result = compare_dicts({"a": 1, "b": 2}, {"b": 2, "a": 1})
+        assert result.are_equal is True
+        assert result.differences == DictDiff(added={}, removed={}, changed={})
+
+    def test_changed_value_at_root(self):
+        result = compare_dicts({"role": "dev"}, {"role": "lead"})
+        assert result.are_equal is False
+        assert result.differences.changed == {"role": ("dev", "lead")}
+        assert result.differences.added == {}
+        assert result.differences.removed == {}
+
+    def test_added_key(self):
+        result = compare_dicts({"a": 1}, {"a": 1, "b": 2})
+        assert result.differences.added == {"b": 2}
+        assert result.differences.changed == {}
+        assert result.differences.removed == {}
+
+    def test_removed_key(self):
+        result = compare_dicts({"a": 1, "b": 2}, {"a": 1})
+        assert result.differences.removed == {"b": 2}
+        assert result.differences.added == {}
+
+    def test_nested_changed_uses_dotted_path(self):
+        a = {"user": {"address": {"zip": "12345"}}}
+        b = {"user": {"address": {"zip": "54321"}}}
+        result = compare_dicts(a, b)
+        assert result.differences.changed == {
+            "user.address.zip": ("12345", "54321")
+        }
+
+    def test_nested_added_and_removed_paths(self):
+        a = {"user": {"name": "Ada"}}
+        b = {"user": {"role": "lead"}}
+        result = compare_dicts(a, b)
+        assert result.differences.removed == {"user.name": "Ada"}
+        assert result.differences.added == {"user.role": "lead"}
+        assert result.differences.changed == {}
+
+    def test_dict_replaced_by_scalar_is_changed(self):
+        a = {"user": {"name": "Ada"}}
+        b = {"user": 5}
+        result = compare_dicts(a, b)
+        assert result.differences.changed == {"user": ({"name": "Ada"}, 5)}
+
+    def test_nested_list_reported_as_single_changed_entry(self):
+        a = {"items": [1, 2, 3]}
+        b = {"items": [3, 2, 1]}
+        result = compare_dicts(a, b)
+        assert result.differences.changed == {"items": ([1, 2, 3], [3, 2, 1])}
+
+    def test_mixed_changes_in_one_pass(self):
+        a = {"keep": 1, "drop": 2, "mod": 3}
+        b = {"keep": 1, "mod": 30, "new": 4}
+        result = compare_dicts(a, b)
+        assert result.differences.removed == {"drop": 2}
+        assert result.differences.added == {"new": 4}
+        assert result.differences.changed == {"mod": (3, 30)}
+
+    def test_unpackable_like_a_tuple(self):
+        are_equal, differences = compare_dicts({"a": 1}, {"a": 2})
+        assert are_equal is False
+        assert differences.changed == {"a": (1, 2)}
+
+    def test_non_string_keys_are_stringified_in_path(self):
+        result = compare_dicts({1: "a"}, {1: "b"})
+        assert result.differences.changed == {"1": ("a", "b")}
+
+
+# ---------------------------------------------------------------------------
+# dict_lists_are_equal
+# ---------------------------------------------------------------------------
+class TestDictListsAreEqual:
+    def test_identical_lists(self):
+        assert dict_lists_are_equal([{"a": 1}], [{"a": 1}])
+
+    def test_order_is_ignored(self):
+        a = [{"id": 1}, {"id": 2}, {"id": 3}]
+        b = [{"id": 3}, {"id": 1}, {"id": 2}]
+        assert dict_lists_are_equal(a, b)
+
+    def test_both_empty(self):
+        assert dict_lists_are_equal([], [])
+
+    def test_different_lengths(self):
+        assert not dict_lists_are_equal([{"a": 1}], [{"a": 1}, {"a": 1}])
+
+    def test_duplicates_are_counted(self):
+        a = [{"x": 1}, {"x": 1}]
+        b = [{"x": 1}, {"x": 1}]
+        assert dict_lists_are_equal(a, b)
+
+    def test_duplicate_count_mismatch(self):
+        a = [{"x": 1}, {"x": 1}]
+        b = [{"x": 1}, {"x": 2}]
+        assert not dict_lists_are_equal(a, b)
+
+    def test_nested_structures_with_unordered_outer_list(self):
+        a = [{"tags": ["a", "b"], "n": 1}, {"n": 2}]
+        b = [{"n": 2}, {"n": 1, "tags": ["a", "b"]}]
+        assert dict_lists_are_equal(a, b)
+
+    def test_nested_list_order_still_matters(self):
+        a = [{"tags": ["a", "b"]}]
+        b = [{"tags": ["b", "a"]}]
+        assert not dict_lists_are_equal(a, b)
+
+    def test_datetime_in_elements(self):
+        dt = datetime(2024, 1, 1)
+        assert dict_lists_are_equal([{"t": dt}], [{"t": datetime(2024, 1, 1)}])
+
+
+# ---------------------------------------------------------------------------
+# compare_dict_lists
+# ---------------------------------------------------------------------------
+class TestCompareDictLists:
+    def test_returns_dict_list_comparison_type(self):
+        result = compare_dict_lists([{"a": 1}], [{"a": 1}])
+        assert isinstance(result, DictListComparison)
+        assert isinstance(result.differences, DictListDiff)
+
+    def test_equal_lists_have_empty_diff(self):
+        result = compare_dict_lists([{"a": 1}], [{"a": 1}])
+        assert result.are_equal is True
+        assert result.differences == DictListDiff(only_in_a=[], only_in_b=[])
+
+    def test_only_in_a_and_only_in_b(self):
+        result = compare_dict_lists([{"id": 1}, {"id": 2}], [{"id": 2}, {"id": 3}])
+        assert result.are_equal is False
+        assert result.differences.only_in_a == [{"id": 1}]
+        assert result.differences.only_in_b == [{"id": 3}]
+
+    def test_only_in_a_preserves_source_order(self):
+        a = [{"id": 3}, {"id": 1}, {"id": 2}]
+        b = [{"id": 2}]
+        result = compare_dict_lists(a, b)
+        assert result.differences.only_in_a == [{"id": 3}, {"id": 1}]
+        assert result.differences.only_in_b == []
+
+    def test_duplicates_are_reported_per_surplus_count(self):
+        a = [{"x": 1}, {"x": 1}, {"x": 1}]
+        b = [{"x": 1}]
+        result = compare_dict_lists(a, b)
+        assert result.differences.only_in_a == [{"x": 1}, {"x": 1}]
+        assert result.differences.only_in_b == []
+
+    def test_reordered_lists_are_equal(self):
+        a = [{"id": 1}, {"id": 2}]
+        b = [{"id": 2}, {"id": 1}]
+        result = compare_dict_lists(a, b)
+        assert result.are_equal is True
+        assert result.differences.only_in_a == []
+        assert result.differences.only_in_b == []
+
+    def test_unpackable_like_a_tuple(self):
+        are_equal, differences = compare_dict_lists([{"a": 1}], [{"a": 2}])
+        assert are_equal is False
+        assert differences.only_in_a == [{"a": 1}]
+        assert differences.only_in_b == [{"a": 2}]
+
+
+# ---------------------------------------------------------------------------
+# Canonicalization of complex leaf types in list comparison
+# ---------------------------------------------------------------------------
+class TestListLeafTypes:
+    def test_set_values_are_order_independent(self):
+        a = [{"tags": {1, 2, 3}}]
+        b = [{"tags": {3, 2, 1}}]
+        assert dict_lists_are_equal(a, b)
+
+    def test_frozenset_values(self):
+        a = [{"tags": frozenset({1, 2})}]
+        b = [{"tags": frozenset({2, 1})}]
+        assert dict_lists_are_equal(a, b)
+
+    def test_tuple_values_are_order_sensitive(self):
+        assert dict_lists_are_equal([{"t": (1, 2)}], [{"t": (1, 2)}])
+        assert not dict_lists_are_equal([{"t": (1, 2)}], [{"t": (2, 1)}])
+
+    def test_container_type_does_not_collide(self):
+        # A list and a tuple holding the same items must not be treated equal.
+        assert not dict_lists_are_equal([{"v": [1, 2]}], [{"v": (1, 2)}])
+
+    def test_unhashable_leaf_raises_type_error(self):
+        with pytest.raises(TypeError, match="unhashable"):
+            compare_dict_lists([{"data": bytearray(b"x")}], [])
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+class TestValidation:
+    @pytest.mark.parametrize("value", [None, 1, "x", ["a"], (1, 2), {1, 2}])
+    def test_compare_dicts_rejects_non_dict_a(self, value):
+        with pytest.raises(TypeError):
+            compare_dicts(value, {})
+
+    @pytest.mark.parametrize("value", [None, 1, "x", ["a"]])
+    def test_compare_dicts_rejects_non_dict_b(self, value):
+        with pytest.raises(TypeError):
+            compare_dicts({}, value)
+
+    @pytest.mark.parametrize("value", [None, 1, "x", {"a": 1}])
+    def test_compare_dict_lists_rejects_non_list_a(self, value):
+        with pytest.raises(TypeError):
+            compare_dict_lists(value, [])
+
+    @pytest.mark.parametrize("value", [None, 1, "x", {"a": 1}])
+    def test_compare_dict_lists_rejects_non_list_b(self, value):
+        with pytest.raises(TypeError):
+            compare_dict_lists([], value)
+
+    def test_compare_dict_lists_rejects_non_dict_element(self):
+        with pytest.raises(TypeError):
+            compare_dict_lists([{"a": 1}, "not a dict"], [])
+
+    def test_error_message_names_offending_index(self):
+        with pytest.raises(TypeError, match="index 1"):
+            compare_dict_lists([{"a": 1}, 42], [])
+
+    def test_dicts_are_equal_rejects_non_dict(self):
+        with pytest.raises(TypeError):
+            dicts_are_equal({"a": 1}, None)
+
+    def test_dict_lists_are_equal_rejects_non_list(self):
+        with pytest.raises(TypeError):
+            dict_lists_are_equal([{"a": 1}], None)
+
+
+# ---------------------------------------------------------------------------
+# Consistency invariant: *_are_equal must agree with compare_* .are_equal
+# ---------------------------------------------------------------------------
+class TestConsistency:
+    _DICT_CASES = [
+        ({}, {}),
+        ({"a": 1}, {"a": 1}),
+        ({"a": 1}, {"a": 2}),
+        ({"a": {"b": 1}}, {"a": {"b": 1}}),
+        ({"a": {"b": 1}}, {"a": {"b": 2}}),
+        ({"a": [1, 2]}, {"a": [2, 1]}),
+    ]
+
+    _LIST_CASES = [
+        ([], []),
+        ([{"a": 1}], [{"a": 1}]),
+        ([{"a": 1}], [{"a": 2}]),
+        ([{"a": 1}, {"b": 2}], [{"b": 2}, {"a": 1}]),
+        ([{"a": 1}, {"a": 1}], [{"a": 1}]),
+    ]
+
+    @pytest.mark.parametrize(("a", "b"), _DICT_CASES)
+    def test_dict_bool_matches_comparison(self, a, b):
+        assert dicts_are_equal(a, b) == compare_dicts(a, b).are_equal
+
+    @pytest.mark.parametrize(("a", "b"), _LIST_CASES)
+    def test_list_bool_matches_comparison(self, a, b):
+        assert dict_lists_are_equal(a, b) == compare_dict_lists(a, b).are_equal

--- a/raccoontools/uv.lock
+++ b/raccoontools/uv.lock
@@ -282,7 +282,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.1.0"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -291,9 +291,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/84/0e/b5858858d74958632c49b72cb25a3976ff9f632397626715be71c89d3971/pytest-9.1.0.tar.gz", hash = "sha256:41dd9148c08072446394cefd3d79701701335a9f4cae69ba92e39f6c7f5c061c", size = 1634181, upload-time = "2026-06-13T18:52:45.983Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl", hash = "sha256:8ebb0e7888bdf2bdfc602ec51f8f62d50200af37356c74e503c79a94f5c81f32", size = 386453, upload-time = "2026-06-13T18:52:44.045Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
@@ -319,7 +319,7 @@ wheels = [
 
 [[package]]
 name = "raccoontools"
-version = "3.5.0"
+version = "3.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "idna" },
@@ -346,7 +346,7 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = "==9.1.0" }]
+dev = [{ name = "pytest", specifier = "==9.1.1" }]
 
 [[package]]
 name = "requests"


### PR DESCRIPTION
### Added
- `comparators.dict_comparators`: New comparison helpers for dictionaries and lists of dictionaries.
  - `dicts_are_equal` / `compare_dicts`: deep, key-order-independent dictionary comparison. `compare_dicts` returns a `DictComparison` named tuple with `are_equal` and a `DictDiff` (`added` / `removed` / `changed`) keyed by dotted paths (e.g. `"user.address.zip"`). Nested dictionaries are recursed into; every other value (including nested lists, `datetime`, and custom types) is compared as an opaque leaf.
  - `dict_lists_are_equal` / `compare_dict_lists`: order-independent `list[dict]` comparison (the lists are treated as multisets, so duplicates are counted). `compare_dict_lists` returns a `DictListComparison` with `only_in_a` / `only_in_b`.
  - The `*_are_equal` functions delegate to their `compare_*` counterparts, so the boolean and detailed results can never disagree. All functions raise `TypeError` for invalid input types.
